### PR TITLE
Create deployment infrastructure for the app

### DIFF
--- a/.github/workflows/main-push-cd.yml
+++ b/.github/workflows/main-push-cd.yml
@@ -19,4 +19,5 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
       - run: npm ci
+      - run: npm run deploy-app-main
       - run: npm run deploy-storybook-main

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ npm run dev
 
 Open [http://localhost:4321](http://localhost:4321) with your browser to see the result.
 
+To deploy your local app to a shared location:
+
+```bash
+npm run deploy-app-dev
+```
+
+Once this has built and deployed successfully the Astro.js application will be available at http://hid-ppt-app-dev.s3-website.eu-west-2.amazonaws.com.
+
 ## Storybook
 
 To run Storybook development server:
@@ -100,4 +108,4 @@ The [main-pr-push-iac.yml workflow](./.github/workflows/main-pr-push-iac.yml) is
 
 ### Push deployment
 
-The [main-push-cd.yml workflow](./.github/workflows/main-push-cd.yml) is configured to build and deploy Storybook on every push targeting the main branch. Once deployed successfully Storybook will be available at at an address defined by the AWS Cloudfront distribution.
+The [main-push-cd.yml workflow](./.github/workflows/main-push-cd.yml) is configured to build and deploy the Astro application and Storybook on every push that targets the main branch. Once deployed successfully, the Astro application and Storybook will be available at an address defined by the AWS Cloudfront distribution.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To deploy your local app to a shared location:
 npm run deploy-app-dev
 ```
 
-Once this has built and deployed successfully the Astro.js application will be available at http://hid-ppt-app-dev.s3-website.eu-west-2.amazonaws.com.
+Once this has built and deployed successfully, the Astro.js application will be available at an address defined by the AWS Cloudfront distribution.
 
 ## Storybook
 
@@ -84,7 +84,7 @@ To deploy your local storybook to a shared location:
 npm run deploy-storybook-dev
 ```
 
-Once this has built and deployed successfully Storybook will be available at http://hid-ppt-storybook-dev.s3-website.eu-west-2.amazonaws.com.
+Once this has built and deployed successfully, Storybook will be available at an address defined by the AWS Cloudfront distribution.
 
 ## Linting and code formatting
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "deploy-storybook-dev": "npm run build-storybook && aws s3 sync storybook-static/ s3://hid-ppt-storybook-dev/ --delete",
-    "deploy-storybook-main": "npm run build-storybook && aws s3 sync storybook-static/ s3://hid-ppt-storybook-main/ --delete"
+    "deploy-storybook-main": "npm run build-storybook && aws s3 sync storybook-static/ s3://hid-ppt-storybook-main/ --delete",
+    "deploy-app-dev": "npm run build && aws s3 sync dist/ s3://hid-ppt-app-dev/ --delete",
+    "deploy-app-main": "npm run build && aws s3 sync dist/ s3://hid-ppt-app-main/ --delete"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",


### PR DESCRIPTION
### What

#### Code changes
- The creation of two additional buckets and two corresponding cloudfront distributions were set up within `main.tf` 
- The `iam` bucket policy for the `github-actions` user was updated to allow it to add files to the new `hid-ppt-app-main` bucket
- New scripts were added to the `package.json` file which allow for`npm run deploy-app-dev` and `npm run deploy-app-main` to build the static site and sync files to the `dev` and `main` buckets respectively
- The github workflow was updated within `.github/workflows/main-push-cd.yml` to trigger the building and syncing of files to the `hid-ppt-app-main` bucket on every push that targets the main branch
- The `README.md` was updated to outline the details of the deployment method to `dev` and `main` and also to outline the details of the github workflow. 

#### As part of this work
- The IAC set up as part of this PR has been applied using `terraform apply`
- A deployment was made to the development environment using the newly added `npm run deploy-app-dev` script;  the files uploaded there can be inspected within the AWS S3 instance

### How to review

- Ensure that the IAC that was set up meets the requirement set out in the ticket ([ONSPPT-78](https://anddigitaltransformation.atlassian.net/browse/ONSPPT-78))
- Ensure that the content available when inspecting the buckets and distributions is what is expected
- When a push is made to main (prior to this PR), ensure the app builds successfully and a deployment to `hid-ppt-app-main` bucket is made; this should all be triggered via the updated github workflow

### Who can review
Anyone from the Pandemic Preparedness team