### PR TITLE
Onsppt 114 create link component

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,7 +9,7 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    layout: "centered",
+    // layout: "centered",
   },
 };
 

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,7 +9,6 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    // layout: "centered",
   },
 };
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -7,9 +7,11 @@
   border: none;
   border-radius: $corner-radius-default;
   display: flex;
+  gap: $spacing-2xs;
   justify-content: center;
   line-height: 22px;
   padding: $spacing-2xs $spacing-sm;
+  text-decoration: none;
   @include responsive-token("font-size", $font-sizes-responsive-map, "body");
 }
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -60,6 +60,9 @@ const childrenOptions: ButtonChildrenOptions = {
 const meta = {
   component: Button,
   title: "Components/Button",
+  parameters: {
+    layout: "centered",
+  },
   argTypes: {
     ariaLabel: {
       table: {

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -6,6 +6,9 @@ import type { FooterProps } from "./Footer.interface";
 const meta = {
   component: Footer,
   title: "Components/Footer",
+  parameters: {
+    layout: "centered",
+  },
 } satisfies Meta<typeof Footer>;
 
 export default meta;

--- a/src/components/Link/Link.interface.ts
+++ b/src/components/Link/Link.interface.ts
@@ -2,5 +2,9 @@ import type { LinkData } from "../../types/LinkData";
 
 export interface LinkProps extends LinkData {
   asButton?: boolean;
-  disabled?: boolean;
+  buttonVariant?:
+    | "primary"
+    | "primary-inverse"
+    | "secondary"
+    | "secondary-inverse";
 }

--- a/src/components/Link/Link.interface.ts
+++ b/src/components/Link/Link.interface.ts
@@ -1,0 +1,6 @@
+import type { LinkData } from "../../types/LinkData";
+
+export interface LinkProps extends LinkData {
+  asButton?: boolean;
+  disabled?: boolean;
+}

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,15 +1,17 @@
+@use "../../styles/global/mixins" as *;
 @use "../../styles/global/variables" as *;
 
 .link {
-  color: $color-text-default;
-  font-weight: 600;
-  text-decoration: none;
   align-items: center;
-  justify-content: center;
+  color: $color-text-default;
   display: flex;
   flex-direction: row;
+  font-weight: 600;
   gap: $spacing-2xs;
+  justify-content: center;
+  text-decoration: none;
   vertical-align: middle;
+  @include responsive-token("font-size", $font-sizes-responsive-map, "body");
 
   &:active {
     color: $color-text-link-hover;
@@ -41,18 +43,6 @@
 }
 
 .link__icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  > .ri {
-    flex-shrink: 0;
-    width: $icon-link-icon-size;
-    height: $icon-link-icon-size;
-  }
-}
-
-.button__label-icon {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/Link/Link.scss
+++ b/src/components/Link/Link.scss
@@ -1,0 +1,59 @@
+@use "../../styles/global/variables" as *;
+
+.link {
+  color: $color-text-default;
+  font-weight: 600;
+  text-decoration: none;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: row;
+  gap: $spacing-2xs;
+  vertical-align: middle;
+
+  &:active {
+    color: $color-text-link-hover;
+  }
+
+  &:hover {
+    color: $color-text-link-hover;
+  }
+
+  &:visited {
+    color: $color-text-link-hover;
+  }
+}
+
+.link--inverse {
+  color: $color-text-inverse;
+
+  &:active {
+    color: $color-text-inverse;
+  }
+
+  &:hover {
+    color: $color-text-inverse;
+  }
+
+  &:visited {
+    color: $color-text-inverse;
+  }
+}
+
+.link__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  > .ri {
+    flex-shrink: 0;
+    width: $icon-link-icon-size;
+    height: $icon-link-icon-size;
+  }
+}
+
+.button__label-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -28,15 +28,16 @@ const meta = {
         disable: true,
       },
     },
+    buttonVariant: {
+      table: {
+        disable: true,
+      },
+    },
     href: {
       control: { type: "select" },
       name: "Link href",
       options: Object.keys(hrefOptions),
       mapping: hrefOptions,
-    },
-    disabled: {
-      control: { type: "boolean" },
-      name: "Disabled",
     },
     target: {
       table: {
@@ -49,10 +50,20 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const LinkStory = {
-  name: "Link",
+export const LinkNormalStory = {
+  name: "Rendered normally",
   args: {
-    disabled: false,
+    asButton: false,
+    href: hrefOptions.EmptyLink,
+    label: "My link",
+  },
+} satisfies Story;
+
+export const LinkAsButtonStory = {
+  name: "Rendered as a button",
+  args: {
+    asButton: true,
+    buttonVariant: "primary",
     href: hrefOptions.EmptyLink,
     label: "My link",
   },

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Link } from "./Link";
+
+// Defines some options for button children so we can show how different button content is rendered
+interface HrefOptions {
+  EmptyLink: string;
+  InternalNavigationLink: string;
+  ExternalLink: string;
+}
+
+// Define the href opions
+const hrefOptions: HrefOptions = {
+  EmptyLink: "#",
+  InternalNavigationLink: "/about",
+  ExternalLink: "https://www.ons.gov.uk/",
+};
+
+const meta = {
+  component: Link,
+  title: "Components/Link",
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    asButton: {
+      table: {
+        disable: true,
+      },
+    },
+    href: {
+      control: { type: "select" },
+      name: "Link href",
+      options: Object.keys(hrefOptions),
+      mapping: hrefOptions,
+    },
+    disabled: {
+      control: { type: "boolean" },
+      name: "Disabled",
+    },
+    target: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LinkStory = {
+  name: "Link",
+  args: {
+    disabled: false,
+    href: hrefOptions.EmptyLink,
+    label: "My link",
+  },
+} satisfies Story;

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -34,7 +34,7 @@ export const Link: FC<LinkProps> = (props) => {
   }
 
   return (
-    <a className={classes} href={props.href}>
+    <a className={classes} href={props.href} target={props.target}>
       <Label />
     </a>
   );

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,10 +1,19 @@
 import type { FC } from "react";
 import { RiArrowRightLine, RiShareBoxFill } from "@remixicon/react";
 
-import "./Link.scss";
+import "../Button/Button.scss";
 import type { LinkProps } from "./Link.interface";
 
 export const Link: FC<LinkProps> = (props) => {
+  // Set css class based on whether we are rendering as a button or not
+  let classes = "";
+
+  if (props.asButton) {
+    classes = `button button--${props.buttonVariant}`.trim();
+  } else {
+    classes = "link";
+  }
+
   // Just render the label text by default
   let Label: FC = () => <>{props.label}</>;
 
@@ -25,7 +34,7 @@ export const Link: FC<LinkProps> = (props) => {
   }
 
   return (
-    <a className="link" href={props.href}>
+    <a className={classes} href={props.href}>
       <Label />
     </a>
   );

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,0 +1,32 @@
+import type { FC } from "react";
+import { RiArrowRightLine, RiShareBoxFill } from "@remixicon/react";
+
+import "./Link.scss";
+import type { LinkProps } from "./Link.interface";
+
+export const Link: FC<LinkProps> = (props) => {
+  // Just render the label text by default
+  let Label: FC = () => <>{props.label}</>;
+
+  if (props.href.startsWith("http")) {
+    // If href starts with http, render as an external link to include icon
+    Label = () => (
+      <>
+        {props.label} <RiShareBoxFill className="link__icon" />
+      </>
+    );
+  } else if (props.href.startsWith("/")) {
+    // If href starts with /, this is an internal navigation link so render with right arrow icon
+    Label = () => (
+      <>
+        {props.label} <RiArrowRightLine className="link__icon" />
+      </>
+    );
+  }
+
+  return (
+    <a className="link" href={props.href}>
+      <Label />
+    </a>
+  );
+};

--- a/src/styles/global/_variables.scss
+++ b/src/styles/global/_variables.scss
@@ -107,6 +107,7 @@ $color-button-secondary-inverse-selected: $color-surface-inverse;
 $color-text-default: $color-grey-900;
 $color-text-inverse: $color-grey-100;
 $color-text-accent: $color-primary-500;
+$color-text-link-hover: $color-state-link-hover;
 
 // Corner radius
 $corner-radius-default: $spacing-3;
@@ -121,3 +122,7 @@ $spacing-2xs: $spacing-2;
 
 // Button sizing
 $button-border-width-default: $spacing-1;
+
+// Icons
+$icon-link-gap: $spacing-2xs;
+$icon-link-icon-size: $font-size-2;

--- a/src/styles/typography.stories.tsx
+++ b/src/styles/typography.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { RiArrowRightLine, RiShareBoxFill } from "@remixicon/react";
 
 const meta = {
   title: "Styles/Typography",

--- a/src/styles/typography.stories.tsx
+++ b/src/styles/typography.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { RiArrowRightLine, RiShareBoxFill } from "@remixicon/react";
 
 const meta = {
   title: "Styles/Typography",
@@ -60,15 +61,6 @@ export const Paragraphs = {
     <div>
       <h1 className="heading-l">Paragraphs</h1>
       <p className="body">The default paragraph font size is 1.25rem (20px).</p>
-    </div>
-  ),
-} satisfies Story;
-
-export const LinksStory = {
-  name: "Links",
-  render: () => (
-    <div>
-      <h1 className="heading-l">Links</h1>
     </div>
   ),
 } satisfies Story;

--- a/src/styles/typography.stories.tsx
+++ b/src/styles/typography.stories.tsx
@@ -59,6 +59,7 @@ export const Paragraphs = {
   render: () => (
     <div>
       <h1 className="heading-l">Paragraphs</h1>
+      <p className="body">The default paragraph font size is 1.25rem (20px).</p>
     </div>
   ),
 } satisfies Story;

--- a/src/types/LinkData.ts
+++ b/src/types/LinkData.ts
@@ -2,4 +2,5 @@ export interface LinkData {
   href: string;
   label: string;
   disabled?: boolean;
+  target?: "_self" | "_blank" | "_parent" | "_top";
 }


### PR DESCRIPTION
[ONSPPT-114](https://anddigitaltransformation.atlassian.net/browse/ONSPPT-114) Create link component

I initially tried to do this in styles alone but seemed much easier to create a component to do it. The issue with using styles alone was trying to dynamically append an icon to the link text. I could do this using the `::after` pseudo class but getting it to follow the `:hover` and other state colours was hard work. Hopefully we will be able to get these links to render in line with content from the cms.

- Updated `.storybook/preview.ts` to remove global story centering. I am now doing this on a per component basis so styles aren't centred by default
- Updated `src/components/Button/Button.scss` to ensure styles are loaded correctly when rendering a button as `<button>` and when rendering a link as a button using `<a>`
- Updated `src/components/Button/Button.stories.tsx` and `src/components/Footer/Footer.stories.tsx` to centre stories on a per component basis
- Added `src/components/Link/*` files to include new `Link` component and associated styles and stories
- Updated `src/styles/global/_variables.scss` to include new variables required for the `Link` component
- Updated `src/styles/typography.stories.tsx` to remove the `Links` story as we are using a component for this not styles
- Updated `src/types/LinkData.ts` `LinkData` type to include new parameters