### PR TITLE
Bonus PR – Children props for Header component 

### DIFF
--- a/src/components/Header/Header.interface.ts
+++ b/src/components/Header/Header.interface.ts
@@ -1,5 +1,8 @@
+import type { ReactNode } from "react";
+
 export interface HeaderProps {
-  subheading: string;
-  heading: string;
+  children: ReactNode;
   description: string;
+  heading: string;
+  subheading: string;
 }

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import Header from "./Header";
 import type { HeaderProps } from "./Header.interface";
+import SearchBar from "../SearchBar/SearchBar";
 
 const meta = {
   component: Header,
@@ -11,14 +12,19 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const HeaderSearchBarComponent = (
+  <SearchBar ariaLabel="Search" placeholder="Search learning resources" />
+);
+
 const headerData: HeaderProps = {
-  subheading: "Home",
-  heading: "Resilience Through Data",
+  children: HeaderSearchBarComponent,
   description:
     "Empowering National Statistical Offices with the skills and tools to support evidence based response to infectious disease outbreaks.",
+  heading: "Resilience Through Data",
+  subheading: "Home",
 };
 
 export const HeaderStory = {
-  name: "Header",
   args: headerData,
+  name: "Header",
 } satisfies Story;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,16 +2,20 @@ import type { FC } from "react";
 
 import type { HeaderProps } from "./Header.interface";
 import styles from "./Header.module.scss";
-import SearchBar from "../SearchBar/SearchBar";
 
-const Header: FC<HeaderProps> = ({ subheading, heading, description }) => {
+const Header: FC<HeaderProps> = ({
+  children,
+  description,
+  heading,
+  subheading,
+}) => {
   return (
     <header>
       <div className={styles["header-content"]}>
         <h2 className="body">{subheading}</h2>
         <h1 className="heading-xl">{heading}</h1>
         <p className="heading-s">{description}</p>
-        <SearchBar placeholder="TODO" ariaLabel="search" />
+        {children}
       </div>
     </header>
   );


### PR DESCRIPTION
#### What

This PR is an improvement to existing functionality.

- `SearchBar` is now passable to `Header` via props with `{children}`. 
- Within the storybook the `Header` story is passed a `SearchBar` component