### PR TITLE
Onsppt 165 component build text modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/react": "^4.3.0",
         "@fontsource-variable/open-sans": "^5.2.6",
         "@remixicon/react": "^4.6.0",
+        "@types/sanitize-html": "^2.16.0",
         "astro": "^5.11.1",
         "clsx": "^2.1.1",
         "marked": "^16.3.0",
@@ -2769,6 +2770,15 @@
       "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
       "dev": true
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-l6rX1MUXje5ztPT0cAFtUayXF06DqPhRyfVXareEN5gGCFaP/iwsxIyKODr9XDhfxPpN6vXUFNfo5kZMXCxBtw==",
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -4368,6 +4378,73 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dset": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
@@ -5766,6 +5843,37 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-cache-semantics": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@remixicon/react": "^4.6.0",
         "astro": "^5.11.1",
         "clsx": "^2.1.1",
+        "marked": "^16.3.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "uuid": "^13.0.0"
@@ -6596,6 +6597,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
+      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/sanitize-html": "^2.16.0",
         "astro": "^5.11.1",
         "clsx": "^2.1.1",
+        "dompurify": "^3.2.6",
         "marked": "^16.3.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2779,6 +2780,13 @@
         "htmlparser2": "^8.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -4429,6 +4437,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@astrojs/react": "^4.3.0",
     "@fontsource-variable/open-sans": "^5.2.6",
     "@remixicon/react": "^4.6.0",
+    "@types/sanitize-html": "^2.16.0",
     "astro": "^5.11.1",
     "clsx": "^2.1.1",
     "marked": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@remixicon/react": "^4.6.0",
     "astro": "^5.11.1",
     "clsx": "^2.1.1",
+    "marked": "^16.3.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "uuid": "^13.0.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/sanitize-html": "^2.16.0",
     "astro": "^5.11.1",
     "clsx": "^2.1.1",
+    "dompurify": "^3.2.6",
     "marked": "^16.3.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/components/QuestionBank/Explainer/Explainer.interface.ts
+++ b/src/components/QuestionBank/Explainer/Explainer.interface.ts
@@ -1,0 +1,3 @@
+import type { TextModuleProps } from "../../TextModule/TextModule.interface";
+
+export interface ExplainerProps extends TextModuleProps {}

--- a/src/components/QuestionBank/Explainer/Explainer.module.scss
+++ b/src/components/QuestionBank/Explainer/Explainer.module.scss
@@ -1,0 +1,5 @@
+@use "../../../styles/global/variables" as *;
+
+.explainer-bg {
+  background-color: $color-surface-subtle;
+}

--- a/src/components/QuestionBank/Explainer/Explainer.stories.tsx
+++ b/src/components/QuestionBank/Explainer/Explainer.stories.tsx
@@ -1,16 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import DOMPurify from "dompurify";
 
-import markdownContent from "../../content/text-module-content.md?raw";
-import { parseMarkdown } from "../../helpers/parseMarkdown";
-import { TextModule } from "./TextModule";
-import type { TextModuleProps } from "./TextModule.interface";
+import markdownContent from "../../../content/QuestionBank/explainer.md?raw";
+import { parseMarkdown } from "../../../helpers/parseMarkdown";
+import { Explainer } from "./Explainer";
+import type { ExplainerProps } from "./Explainer.interface";
 
 const meta = {
-  component: TextModule,
-  title: "Components/TextModule",
+  component: Explainer,
+  title: "Organisms/QuestionBank/Explainer",
   parameters: {
-    layout: "centered",
+    layout: "fullscreen",
   },
   argTypes: {
     className: {
@@ -24,7 +24,7 @@ const meta = {
       },
     },
   },
-} satisfies Meta<typeof TextModule>;
+} satisfies Meta<typeof Explainer>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -32,14 +32,12 @@ type Story = StoryObj<typeof meta>;
 // Use helper to parse and sanitize markdown to html
 const htmlContent = await parseMarkdown(markdownContent);
 
-const textModuleProps: TextModuleProps = {
+const explainerProps: ExplainerProps = {
   // Sanitizing using dompurify here as this is running client side
   htmlContent: DOMPurify.sanitize(htmlContent),
-  // Adding classname here just for storybook integration
-  className: "container-lg",
 };
 
-export const TextModuleStory = {
-  name: "Text Module",
-  args: textModuleProps,
+export const ExplainerStory = {
+  name: "Explainer",
+  args: explainerProps,
 } satisfies Story;

--- a/src/components/QuestionBank/Explainer/Explainer.tsx
+++ b/src/components/QuestionBank/Explainer/Explainer.tsx
@@ -1,0 +1,17 @@
+import clsx from "clsx";
+import type { FC } from "react";
+
+import { TextModule } from "../../TextModule/TextModule";
+import type { ExplainerProps } from "./Explainer.interface";
+import styles from "./Explainer.module.scss";
+
+// Renders input `htmlContent` using the `TextModule` component
+export const Explainer: FC<ExplainerProps> = (props) => {
+  return (
+    <div className={clsx("w-100", styles["explainer-bg"])}>
+      <div className={clsx("container-lg", "py-4")}>
+        <TextModule {...props} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/TextModule/TextModule.interface.ts
+++ b/src/components/TextModule/TextModule.interface.ts
@@ -1,4 +1,4 @@
 export interface TextModuleProps {
-  content: string;
+  htmlContent: string;
   className?: string;
 }

--- a/src/components/TextModule/TextModule.interface.ts
+++ b/src/components/TextModule/TextModule.interface.ts
@@ -1,0 +1,4 @@
+export interface TextModuleProps {
+  content: string;
+  className?: string;
+}

--- a/src/components/TextModule/TextModule.stories.tsx
+++ b/src/components/TextModule/TextModule.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { TextModule } from "./TextModule";
+import type { TextModuleProps } from "./TextModule.interface";
+
+const meta = {
+  component: TextModule,
+  title: "Components/TextModule",
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof TextModule>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const textModuleProps: TextModuleProps = {
+  content: "Search all resources",
+};
+
+export const HeaderStory = {
+  name: "Text Module",
+  args: textModuleProps,
+} satisfies Story;

--- a/src/components/TextModule/TextModule.stories.tsx
+++ b/src/components/TextModule/TextModule.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
+
+import markdownContent from "../../content/text-module-content.md?raw";
+import { parseMarkdown } from "../../helpers/parseMarkdown";
 import { TextModule } from "./TextModule";
 import type { TextModuleProps } from "./TextModule.interface";
 
@@ -8,13 +11,30 @@ const meta = {
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+    htmlContent: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 } satisfies Meta<typeof TextModule>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Use helper to parse and sanitize markdown to html
+const htmlContent = await parseMarkdown(markdownContent);
+
 const textModuleProps: TextModuleProps = {
-  content: "Search all resources",
+  htmlContent: htmlContent,
+  // Adding classname here just for storybook integration
+  className: "container-lg",
 };
 
 export const HeaderStory = {

--- a/src/components/TextModule/TextModule.tsx
+++ b/src/components/TextModule/TextModule.tsx
@@ -1,0 +1,8 @@
+import clsx from "clsx";
+import type { FC } from "react";
+
+import type { TextModuleProps } from "./TextModule.interface";
+
+export const TextModule: FC<TextModuleProps> = (props) => {
+  return <div className={clsx("row")}>{props.content}</div>;
+};

--- a/src/components/TextModule/TextModule.tsx
+++ b/src/components/TextModule/TextModule.tsx
@@ -3,6 +3,7 @@ import type { FC } from "react";
 
 import type { TextModuleProps } from "./TextModule.interface";
 
+// Renders input `htmlContent` within outer div
 export const TextModule: FC<TextModuleProps> = (props) => {
   return (
     <div

--- a/src/components/TextModule/TextModule.tsx
+++ b/src/components/TextModule/TextModule.tsx
@@ -4,5 +4,10 @@ import type { FC } from "react";
 import type { TextModuleProps } from "./TextModule.interface";
 
 export const TextModule: FC<TextModuleProps> = (props) => {
-  return <div className={clsx("row")}>{props.content}</div>;
+  return (
+    <div
+      className={clsx("row", props.className && props.className)}
+      dangerouslySetInnerHTML={{ __html: props.htmlContent }}
+    />
+  );
 };

--- a/src/content/QuestionBank/explainer.md
+++ b/src/content/QuestionBank/explainer.md
@@ -1,0 +1,3 @@
+Use this section to browse, copy, and paste questions from the Question bank. Get started easily with our [step-by-step guide](https://ons.gov.uk). Alternatively, access questions from [internationally renowned sources here](https://ons.gov.uk).
+
+**Showing 1,001 of 1,001 questions.**

--- a/src/content/text-module-content.md
+++ b/src/content/text-module-content.md
@@ -1,0 +1,33 @@
+# Sample Markdown Document
+
+## Introduction
+
+This is an example markdown document demonstrating various elements such as headings, lists, and tables.
+
+## Bulleted List
+
+- First item
+- Second item
+  - Nested item 1
+  - Nested item 2
+- Third item
+
+## Numbered List
+
+1. Step one
+2. Step two
+3. Step three
+   1. Sub-step a
+   2. Sub-step b
+
+## Sample Table
+
+| Name    | Age | Occupation      |
+| ------- | --- | --------------- |
+| Alice   | 30  | Engineer        |
+| Bob     | 25  | Designer        |
+| Charlie | 35  | Product Manager |
+
+## Conclusion
+
+This markdown example covers basic formatting elements useful for documentation or notes.

--- a/src/helpers/parseMarkdown.ts
+++ b/src/helpers/parseMarkdown.ts
@@ -1,9 +1,8 @@
 import { marked } from "marked";
-import sanitizeHtml from "sanitize-html";
+// import sanitizeHtml from "sanitize-html";
 
 // Takes input markdown and outputs as html
 export async function parseMarkdown(markdownContent: string): Promise<string> {
   const contentHtml = await marked.parse(markdownContent);
-  const sanitizedHtml = sanitizeHtml(contentHtml);
-  return sanitizedHtml;
+  return contentHtml;
 }

--- a/src/helpers/parseMarkdown.ts
+++ b/src/helpers/parseMarkdown.ts
@@ -1,0 +1,9 @@
+import { marked } from "marked";
+import sanitizeHtml from "sanitize-html";
+
+// Takes input markdown and outputs as html
+export async function parseMarkdown(markdownContent: string): Promise<string> {
+  const contentHtml = await marked.parse(markdownContent);
+  const sanitizedHtml = sanitizeHtml(contentHtml);
+  return sanitizedHtml;
+}


### PR DESCRIPTION
[ONSPPT-165](https://anddigitaltransformation.atlassian.net/browse/ONSPPT-165) Component Build: Text Modules
I created two components here. `TextModule` is just a basic wrapper around rendering some html content inputted via props. `Explainer` is a QuestionBank specific organism that renders input markdown explainer text.

We will probably configure the CMS to output content in markdown. This allows users to format content without us having to worry about specific components for each different format type.

-  Updated `package-lock.json` and `package.json` to include new [marked](https://www.npmjs.com/package/marked), [dompurify](https://www.npmjs.com/package/dompurify) and [sanitize-html](https://www.npmjs.com/package/sanitize-html). These packages are required to parse markdown to html and also sanitize the html
- Added `src/components/QuestionBank/Explainer/...` files which includes the new `Explainer` Question Bank organism
- Added `src/components/TextModule/...` files for new `TextModule` component
- Added `src/content/QuestionBank/explainer.md` which is markdown content for the `Explainer` organism when rendered using Storybook
- Added `src/content/text-module-content.md` which is markdown content for the `TextModule` component when rendered using Storybook
-  Added `src/helpers/parseMarkdown.ts` for new parseMarkdown` helper that just converts markdown into html
<img width="1298" height="157" alt="image" src="https://github.com/user-attachments/assets/cf777e16-9172-4cc3-becd-763771b03b28" />
