### PR TITLE
Onsppt 175 organism build display header internal pages

### DIFF
--- a/src/components/Core/Header/Header.interface.ts
+++ b/src/components/Core/Header/Header.interface.ts
@@ -1,0 +1,6 @@
+import type { BreadcrumbProps } from "../../Molecules/Breadcrumb/Breadcrumb.interface";
+
+export interface HeaderProps {
+  breadcrumbs: BreadcrumbProps;
+  title: string;
+}

--- a/src/components/Core/Header/Header.module.scss
+++ b/src/components/Core/Header/Header.module.scss
@@ -1,0 +1,5 @@
+@use "../../../styles/global/variables" as *;
+
+.header-bg {
+  background: $gradient-brand-primary-1;
+}

--- a/src/components/Core/Header/Header.stories.tsx
+++ b/src/components/Core/Header/Header.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Header } from "./Header";
+import type { HeaderProps } from "./Header.interface";
+
+const meta = {
+  component: Header,
+  title: "Organisms/Core/Header",
+  argTypes: {
+    breadcrumbs: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const headerProps: HeaderProps = {
+  title: "Basic Data Visualisation",
+  breadcrumbs: {
+    items: [
+      {
+        href: "/",
+        label: "Home",
+        id: "0c6dd168-38da-4a09-b62c-971490cb80b4",
+      },
+      {
+        href: "/",
+        label: "Outputs and Reporting",
+        id: "ff2c92ba-35db-4c63-91fb-1c7f5075c15b",
+      },
+      {
+        href: "/",
+        label: "Basic Data Visualisation",
+        id: "a8aead7c-4748-4c37-961d-caa64ff6558b",
+      },
+    ],
+  },
+};
+
+export const HeaderStory = {
+  name: "Header",
+  args: headerProps,
+} satisfies Story;

--- a/src/components/Core/Header/Header.tsx
+++ b/src/components/Core/Header/Header.tsx
@@ -1,0 +1,25 @@
+import clsx from "clsx";
+import type { FC } from "react";
+
+import { Breadcrumb } from "../../Molecules/Breadcrumb/Breadcrumb";
+import type { HeaderProps } from "./Header.interface";
+import styles from "./Header.module.scss";
+
+export const Header: FC<HeaderProps> = (props) => {
+  return (
+    <div className={clsx("w-100", styles["header-bg"])}>
+      <div className={clsx("container-lg", "py-4", "text-light")}>
+        <div className={clsx("row")}>
+          <div className={clsx("col")}>
+            <Breadcrumb {...props.breadcrumbs} />
+          </div>
+        </div>
+        <div className={clsx("row")}>
+          <div className={clsx("col")}>
+            <h1 className={clsx("heading-l")}>{props.title}</h1>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Home/Header/Header.interface.ts
+++ b/src/components/Home/Header/Header.interface.ts
@@ -1,8 +1,4 @@
-import type { LinkData } from "../../../types/LinkData";
-
-export interface BreadcrumbProps {
-  items: LinkData[];
-}
+import type { BreadcrumbProps } from "../../Molecules/Breadcrumb/Breadcrumb.interface";
 
 export interface HeaderProps {
   breadcrumbs: BreadcrumbProps;

--- a/src/components/Home/Header/Header.tsx
+++ b/src/components/Home/Header/Header.tsx
@@ -1,31 +1,10 @@
 import clsx from "clsx";
 import type { FC } from "react";
 
-import type { BreadcrumbProps, HeaderProps } from "./Header.interface";
-import styles from "./Header.module.scss";
+import { Breadcrumb } from "../../Molecules/Breadcrumb/Breadcrumb";
 import SearchBar from "../../SearchBar/SearchBar";
-
-const Breadcrumb: FC<BreadcrumbProps> = (props) => {
-  return (
-    <nav aria-label="breadcrumb">
-      <ol className={clsx("breadcrumb")}>
-        {props.items.map((item, index, arr) => (
-          <li
-            className={clsx(
-              "breadcrumb-item",
-              index === arr.length - 1 && "active",
-            )}
-            key={item.id}
-          >
-            <a className={clsx("link-light")} href={item.href}>
-              {item.label}
-            </a>
-          </li>
-        ))}
-      </ol>
-    </nav>
-  );
-};
+import type { HeaderProps } from "./Header.interface";
+import styles from "./Header.module.scss";
 
 export const Header: FC<HeaderProps> = (props) => {
   return (

--- a/src/components/Molecules/Breadcrumb/Breadcrumb.interface.ts
+++ b/src/components/Molecules/Breadcrumb/Breadcrumb.interface.ts
@@ -1,0 +1,5 @@
+import type { LinkData } from "../../../types/LinkData";
+
+export interface BreadcrumbProps {
+  items: LinkData[];
+}

--- a/src/components/Molecules/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Molecules/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,32 @@
+import clsx from "clsx";
+import type { FC } from "react";
+
+import type { BreadcrumbProps } from "./Breadcrumb.interface";
+
+export const Breadcrumb: FC<BreadcrumbProps> = (props) => {
+  return (
+    <nav aria-label="breadcrumb">
+      <ol className={clsx("breadcrumb")}>
+        {props.items.map((item, index, arr) => (
+          <li
+            className={clsx(
+              "breadcrumb-item",
+              index === arr.length - 1 && "active",
+            )}
+            key={item.id}
+            aria-current={index === arr.length - 1 && "page"}
+          >
+            {/* Don't render as link if last element in array */}
+            {index === arr.length - 1 ? (
+              item.label
+            ) : (
+              <a className={clsx("link-light")} href={item.href}>
+                {item.label}
+              </a>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};

--- a/src/styles/elements/_typography.scss
+++ b/src/styles/elements/_typography.scss
@@ -17,6 +17,12 @@
   line-height: 120%;
   font-size: 3.75rem;
   font-weight: $font-weight-light;
+
+  @include media-breakpoint-down(md) {
+    line-height: 115%;
+    font-size: 2.25rem;
+    font-weight: $font-weight-bold;
+  }
 }
 
 .heading-m {

--- a/src/styles/global/_variables.scss
+++ b/src/styles/global/_variables.scss
@@ -3,6 +3,7 @@
 // Text
 $color-text-default: $color-brand-primary-700;
 $color-text-accent: $color-brand-primary-500;
+$color-text-inverse: $color-brand-primary-100;
 
 // Surface colors
 $color-surface-default: $color-grey-100;

--- a/src/styles/global/overrides/_breadcrumb.scss
+++ b/src/styles/global/overrides/_breadcrumb.scss
@@ -1,0 +1,16 @@
+@use "../variables" as *;
+// Breadcrumbs
+
+// scss-docs-start breadcrumb-variables
+// $breadcrumb-font-size:              null !default;
+// $breadcrumb-padding-y:              0 !default;
+// $breadcrumb-padding-x:              0 !default;
+// $breadcrumb-item-padding-x:         .5rem !default;
+// $breadcrumb-margin-bottom:          1rem !default;
+// $breadcrumb-bg:                     null !default;
+$breadcrumb-divider-color: $color-text-inverse;
+$breadcrumb-active-color: $color-text-inverse;
+// $breadcrumb-divider:                quote("/") !default;
+// $breadcrumb-divider-flipped:        $breadcrumb-divider !default;
+// $breadcrumb-border-radius:          null !default;
+// scss-docs-end breadcrumb-variables

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -8,6 +8,7 @@
 @import "./global/overrides/forms";
 @import "./global/overrides/list-group";
 @import "./global/overrides/accordion";
+@import "./global/overrides/breadcrumb";
 
 // 3. Include remainder of required Bootstrap stylesheets (including any separate color mode stylesheets)
 @import "./bootstrap-5.3.8/scss/variables";


### PR DESCRIPTION
[ONSPPT-175](https://anddigitaltransformation.atlassian.net/browse/ONSPPT-175) Organism Build: display / Header internal pages
Did some organisation of components and created new `Core/Header` organism for use across pages other than the homepage.

- Added `src/components/Core/Header/...` files for new `Core/Header` organism
- Updated `src/components/Home/Header/...` files to split out existing `Breadcrumb` component as a separate molecule so it can be shared across multiple organisms
- Added `src/components/Molecules/Breadcrumb/...` files for new `Breadcrumb` component. This was originally part of the `Home/Header` organism
- Updated `src/styles/elements/_typography.scss` to include new media breakpoint on `heading-l` which resizes the heading when on smaller devices
- Updated `src/styles/global/_variables.scss` to add new `$color-text-inverse` var for use with breadcrumbs
- Added `src/styles/global/overrides/_breadcrumb.scss` to set divider and active link colours
- Updated `src/styles/index.scss` to include new breadcrumb overrides

<img width="1274" height="167" alt="image" src="https://github.com/user-attachments/assets/fecf00b4-e7f7-42dc-83d8-8f66be640aac" />
