### PR TITLE
Onsppt 182 organism build display question bank question block ts to update ticket

### DIFF
--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.interface.ts
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.interface.ts
@@ -1,0 +1,9 @@
+import type { QuestionData } from "../../../types/QuestionData";
+import type { TagData } from "../../../types/TagData";
+
+export interface QuestionBlockProps {
+  id: string;
+  title: string;
+  tags: TagData[];
+  questions: QuestionData[];
+}

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.module.scss
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.module.scss
@@ -1,0 +1,12 @@
+@use "../../../styles/global/tokens" as *;
+@use "../../../styles/global/variables" as *;
+
+.border-color {
+  // background-color: $color-surface-subtle;
+  border-color: $color-brand-secondary-200 !important;
+}
+
+.question-bg {
+  background-color: $color-surface-subtle;
+  border-color: $color-brand-secondary-200 !important;
+}

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.stories.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   component: QuestionBlock,
   title: "Organisms/QuestionBank/QuestionBlock",
   parameters: {
-    layout: "fullscreen",
+    layout: "centered",
   },
   argTypes: {
     id: {

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.stories.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import DOMPurify from "dompurify";
+import { v4 as uuidv4 } from "uuid";
+
+import q1MdContent from "../../../content/QuestionBank/questions/age/1.md?raw";
+import q2MdContent from "../../../content/QuestionBank/questions/age/2.md?raw";
+import q3MdContent from "../../../content/QuestionBank/questions/age/3.md?raw";
+import q4MdContent from "../../../content/QuestionBank/questions/age/4.md?raw";
+import q5MdContent from "../../../content/QuestionBank/questions/age/5.md?raw";
+import { parseMarkdown } from "../../../helpers/parseMarkdown";
+import { QuestionBlock } from "./QuestionBlock";
+import type { QuestionBlockProps } from "./QuestionBlock.interface";
+
+const meta = {
+  component: QuestionBlock,
+  title: "Organisms/QuestionBank/QuestionBlock",
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    id: {
+      table: {
+        disable: true,
+      },
+    },
+    questions: {
+      table: {
+        disable: true,
+      },
+    },
+    tags: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} satisfies Meta<typeof QuestionBlock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Use helper to parse markdown to html
+const q1HtmlContent = await parseMarkdown(q1MdContent);
+const q2HtmlContent = await parseMarkdown(q2MdContent);
+const q3HtmlContent = await parseMarkdown(q3MdContent);
+const q4HtmlContent = await parseMarkdown(q4MdContent);
+const q5HtmlContent = await parseMarkdown(q5MdContent);
+
+const questionBlockProps: QuestionBlockProps = {
+  id: uuidv4(),
+  title: "Age",
+  tags: [
+    {
+      id: uuidv4(),
+      title: "Demographic information",
+      type: "secondary",
+    },
+  ],
+  questions: [
+    {
+      id: uuidv4(),
+      htmlContent: DOMPurify.sanitize(q1HtmlContent),
+    },
+    {
+      id: uuidv4(),
+      htmlContent: DOMPurify.sanitize(q2HtmlContent),
+    },
+    {
+      id: uuidv4(),
+      htmlContent: DOMPurify.sanitize(q3HtmlContent),
+    },
+    {
+      id: uuidv4(),
+      htmlContent: DOMPurify.sanitize(q4HtmlContent),
+    },
+    {
+      id: uuidv4(),
+      htmlContent: DOMPurify.sanitize(q5HtmlContent),
+    },
+  ],
+};
+
+export const QuestionBlockStory = {
+  name: "QuestionBlock",
+  args: questionBlockProps,
+} satisfies Story;

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
@@ -23,7 +23,7 @@ export const QuestionBlock: FC<QuestionBlockProps> = (props) => {
         ))}
       </div>
       <hr />
-      <div className={clsx("d-flex")}>
+      <div className={clsx("d-flex", "py-4")}>
         <h5 className={clsx("heading-xs")}>{props.title}</h5>
       </div>
       <div className={clsx("d-flex", "flex-column", "gap-2")}>

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
@@ -1,0 +1,27 @@
+import clsx from "clsx";
+import type { FC } from "react";
+
+import { Tag } from "../../Tag/Tag";
+import { TextModule } from "../../TextModule/TextModule";
+import type { QuestionBlockProps } from "./QuestionBlock.interface";
+// import styles from "./Explainer.module.scss";
+
+export const QuestionBlock: FC<QuestionBlockProps> = (props) => {
+  return (
+    <div className={clsx("container")}>
+      <div className={clsx("row")}>
+        {props.tags.map((tag) => (
+          <Tag {...tag} />
+        ))}
+      </div>
+      <div className={clsx("row")}>
+        <h5 className={clsx("heading-xs")}>{props.title}</h5>
+      </div>
+      {props.questions.map((question) => (
+        <div className={clsx("row")} key={question.id}>
+          <TextModule {...question} />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
@@ -4,24 +4,38 @@ import type { FC } from "react";
 import { Tag } from "../../Tag/Tag";
 import { TextModule } from "../../TextModule/TextModule";
 import type { QuestionBlockProps } from "./QuestionBlock.interface";
-// import styles from "./Explainer.module.scss";
+import styles from "./QuestionBlock.module.scss";
 
 export const QuestionBlock: FC<QuestionBlockProps> = (props) => {
   return (
-    <div className={clsx("container")}>
-      <div className={clsx("row")}>
+    <div
+      className={clsx(
+        "container",
+        "p-4",
+        "border",
+        "rounded",
+        styles["border-color"],
+      )}
+    >
+      <div className={clsx("d-inline-flex", "pt-4", "pb-2")}>
         {props.tags.map((tag) => (
           <Tag {...tag} />
         ))}
       </div>
-      <div className={clsx("row")}>
+      <hr />
+      <div className={clsx("d-flex")}>
         <h5 className={clsx("heading-xs")}>{props.title}</h5>
       </div>
-      {props.questions.map((question) => (
-        <div className={clsx("row")} key={question.id}>
-          <TextModule {...question} />
-        </div>
-      ))}
+      <div className={clsx("d-flex", "flex-column", "gap-2")}>
+        {props.questions.map((question) => (
+          <div
+            className={clsx("rounded", "py-2", "px-4", styles["question-bg"])}
+            key={question.id}
+          >
+            <TextModule {...question} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/content/QuestionBank/questions/age/1.md
+++ b/src/content/QuestionBank/questions/age/1.md
@@ -1,0 +1,5 @@
+**1. What is your age?**
+
+- [Select age from 0 to 120]
+- Don’t know
+- Prefer not to say

--- a/src/content/QuestionBank/questions/age/2.md
+++ b/src/content/QuestionBank/questions/age/2.md
@@ -1,0 +1,4 @@
+**2. Are you 16 years or older?**
+
+- Yes
+- No

--- a/src/content/QuestionBank/questions/age/3.md
+++ b/src/content/QuestionBank/questions/age/3.md
@@ -1,0 +1,3 @@
+**3. Please can you tell me how old you are?**
+
+- [Enter age from 0 to 15]

--- a/src/content/QuestionBank/questions/age/4.md
+++ b/src/content/QuestionBank/questions/age/4.md
@@ -1,0 +1,4 @@
+**4. What is your date of birth?**
+
+- [Enter date of birth]
+- Prefer not to say

--- a/src/content/QuestionBank/questions/age/5.md
+++ b/src/content/QuestionBank/questions/age/5.md
@@ -1,0 +1,3 @@
+**5. What was your age on your last birthday?**
+
+- [Select age from 0 to 105 years]

--- a/src/types/QuestionData.ts
+++ b/src/types/QuestionData.ts
@@ -1,0 +1,4 @@
+export interface QuestionData {
+  id: string;
+  htmlContent: string;
+}


### PR DESCRIPTION
[ONSPPT-182](https://anddigitaltransformation.atlassian.net/browse/ONSPPT-182) Organism Build: display / Question bank - question block

New `QuestionBlock` organism:
- I have not included the copy button for each question, this will be done on a future iteration
- The `<li>` as converted from markdown to html are not aligning very well but this can be fixed with a global config change or style change
- I have loaded markdown content file by file from `src/content/QuestionBank/questions/age/` but there is probably a more dynamic way of doing this e.g. by looping through all files in the folder. I have created https://anddigitaltransformation.atlassian.net/browse/ONSPPT-205 for this.

Changes:
- Added `src/components/QuestionBank/QuestionBlock/...` files for new `QuestionBlock` organism
- Added `src/content/QuestionBank/questions/age/...` question content markdown files
- Added `src/types/QuestionData.ts` new `QuestionData` type for use with props.

<img width="460" height="549" alt="image" src="https://github.com/user-attachments/assets/9046f110-6f11-4a27-b4e8-7d482b8df9b9" />
