### PR TITLE
Onsppt 158 assemble page mortality analysis content pages

### DIFF
--- a/src/components/Core/Carousel/Carousel.interface.ts
+++ b/src/components/Core/Carousel/Carousel.interface.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
-import type { CardToolProps } from "../../CardTool/CardTool.interface";
-import type { CardUnitProps } from "../../CardUnit/CardUnit.interface";
+
+import type { CardToolProps } from "@components/CardTool/CardTool.interface";
+import type { CardUnitProps } from "@components/CardUnit/CardUnit.interface";
 
 export type CarouselItemType = "CardTool" | "CardUnit" | "ReactNode";
 

--- a/src/components/Core/Carousel/Carousel.stories.tsx
+++ b/src/components/Core/Carousel/Carousel.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { v4 as uuidv4 } from "uuid";
 
+import type { CardToolProps } from "@components/CardTool/CardTool.interface";
+import type { CardUnitProps } from "@components/CardUnit/CardUnit.interface";
+
 import { Carousel } from "./Carousel";
-import type { CardToolProps } from "../../CardTool/CardTool.interface";
-import type { CardUnitProps } from "../../CardUnit/CardUnit.interface";
 
 const meta = {
   component: Carousel,

--- a/src/components/Core/Carousel/Carousel.tsx
+++ b/src/components/Core/Carousel/Carousel.tsx
@@ -2,11 +2,12 @@ import clsx from "clsx";
 import type { FC } from "react";
 import React, { useState, useRef } from "react";
 
-import { Button } from "../../Button/Button";
-import { CardTool } from "../../CardTool/CardTool";
-import type { CardToolProps } from "../../CardTool/CardTool.interface";
-import { CardUnit } from "../../CardUnit/CardUnit";
-import type { CardUnitProps } from "../../CardUnit/CardUnit.interface";
+import { Button } from "@components/Button/Button";
+import { CardTool } from "@components/CardTool/CardTool";
+import type { CardToolProps } from "@components/CardTool/CardTool.interface";
+import { CardUnit } from "@components/CardUnit/CardUnit";
+import type { CardUnitProps } from "@components/CardUnit/CardUnit.interface";
+
 import type { CarouselProps } from "./Carousel.interface";
 import styles from "./Carousel.module.scss";
 

--- a/src/components/Core/Carousel/Carousel.tsx
+++ b/src/components/Core/Carousel/Carousel.tsx
@@ -129,170 +129,171 @@ export const Carousel: FC<CarouselProps> = ({
   };
 
   return (
-    <div className={clsx(styles.carousel, className)}>
-      {title && (
-        <h2
-          className={clsx(
-            "d-flex",
-            "justify-content-center",
-            "heading-m",
-            "mb-4",
-            styles["carousel-title"],
-          )}
-        >
-          {title}
-        </h2>
-      )}
-      {subtitle && (
-        <p
-          className={clsx(
-            "d-flex",
-            "justify-content-center",
-            "text-center",
-            "mb-4",
-            styles["carousel-subtitle"],
-          )}
-        >
-          {subtitle}
-        </p>
-      )}
-      <div className={styles["carousel-container"]}>
-        {/* Navigation - Previous */}
-        {showNavigation && (
-          <button
-            type="button"
+    <div className={clsx(styles["carousel"], "py-4", className)}>
+      <div className={clsx("container-lg")}>
+        {title && (
+          <h3
             className={clsx(
-              styles["carousel-nav"],
-              styles["carousel-nav--prev"],
-              !canGoPrevious && styles["carousel-nav--disabled"],
+              "d-flex",
+              "justify-content-center",
+              "heading-m",
+              "text-primary",
+              "mb-4",
             )}
-            onClick={handlePrevious}
-            disabled={!canGoPrevious}
-            aria-label="Previous items"
           >
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M15 18L9 12L15 6"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
+            {title}
+          </h3>
         )}
-
-        {/* Carousel Content */}
-        <div className={styles["carousel-content"]}>
-          {/* Mobile tap zones */}
-          <div
-            className={styles["mobile-tap-zone-left"]}
-            onClick={handleLeftTap}
-            onTouchStart={handleTouchStart}
-            onTouchMove={handleTouchMove}
-            onTouchEnd={handleTouchEnd}
-            aria-label="Previous item"
-          />
-          <div
-            className={styles["mobile-tap-zone-right"]}
-            onClick={handleRightTap}
-            onTouchStart={handleTouchStart}
-            onTouchMove={handleTouchMove}
-            onTouchEnd={handleTouchEnd}
-            aria-label="Next item"
-          />
-
-          <div
-            className={styles["carousel-track"]}
-            onTouchStart={handleTouchStart}
-            onTouchMove={handleTouchMove}
-            onTouchEnd={handleTouchEnd}
-          >
-            {getCurrentItems().map((item, index) => (
-              <div
-                key={`carousel-item-${currentIndex}-${index}`}
-                className={styles["carousel-item"]}
-              >
-                {renderItem(item, index)}
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Navigation - Next */}
-        {showNavigation && (
-          <button
-            type="button"
+        {subtitle && (
+          <p
             className={clsx(
-              styles["carousel-nav"],
-              styles["carousel-nav--next"],
-              !canGoNext && styles["carousel-nav--disabled"],
+              "d-flex",
+              "justify-content-center",
+              "text-center",
+              "mb-4",
             )}
-            onClick={handleNext}
-            disabled={!canGoNext}
-            aria-label="Next items"
           >
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M9 18L15 12L9 6"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </button>
+            {subtitle}
+          </p>
         )}
-      </div>
-
-      {/* Pagination Dots */}
-      {showNavigation && items.length > itemsPerView && (
-        <div className={styles["carousel-pagination"]}>
-          {Array.from({ length: maxIndex + 1 }).map((_, index) => (
+        <div className={clsx(styles["carousel-container"])}>
+          {/* Navigation - Previous */}
+          {showNavigation && (
             <button
-              key={index}
               type="button"
               className={clsx(
-                styles["carousel-dot"],
-                index === currentIndex && styles["carousel-dot--active"],
+                styles["carousel-nav"],
+                styles["carousel-nav--prev"],
+                !canGoPrevious && styles["carousel-nav--disabled"],
               )}
-              onClick={() => setCurrentIndex(index)}
-              aria-label={`Go to item ${index + 1}`}
-            />
-          ))}
-        </div>
-      )}
-      {callToAction && (
-        <div
-          className={clsx(
-            "d-flex",
-            "justify-content-center",
-            "mt-4",
-            styles["carousel-call-to-action"],
+              onClick={handlePrevious}
+              disabled={!canGoPrevious}
+              aria-label="Previous items"
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 18L9 12L15 6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
           )}
-        >
-          <Button
-            ariaLabel={callToAction.label}
-            type="button"
-            variant="secondary"
-            onClick={() => (window.location.href = callToAction.href)}
-          >
-            {callToAction.label}
-          </Button>
+
+          {/* Carousel Content */}
+          <div className={styles["carousel-content"]}>
+            {/* Mobile tap zones */}
+            <div
+              className={styles["mobile-tap-zone-left"]}
+              onClick={handleLeftTap}
+              onTouchStart={handleTouchStart}
+              onTouchMove={handleTouchMove}
+              onTouchEnd={handleTouchEnd}
+              aria-label="Previous item"
+            />
+            <div
+              className={styles["mobile-tap-zone-right"]}
+              onClick={handleRightTap}
+              onTouchStart={handleTouchStart}
+              onTouchMove={handleTouchMove}
+              onTouchEnd={handleTouchEnd}
+              aria-label="Next item"
+            />
+
+            <div
+              className={styles["carousel-track"]}
+              onTouchStart={handleTouchStart}
+              onTouchMove={handleTouchMove}
+              onTouchEnd={handleTouchEnd}
+            >
+              {getCurrentItems().map((item, index) => (
+                <div
+                  key={`carousel-item-${currentIndex}-${index}`}
+                  className={styles["carousel-item"]}
+                >
+                  {renderItem(item, index)}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Navigation - Next */}
+          {showNavigation && (
+            <button
+              type="button"
+              className={clsx(
+                styles["carousel-nav"],
+                styles["carousel-nav--next"],
+                !canGoNext && styles["carousel-nav--disabled"],
+              )}
+              onClick={handleNext}
+              disabled={!canGoNext}
+              aria-label="Next items"
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9 18L15 12L9 6"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+          )}
         </div>
-      )}
+
+        {/* Pagination Dots */}
+        {showNavigation && items.length > itemsPerView && (
+          <div className={styles["carousel-pagination"]}>
+            {Array.from({ length: maxIndex + 1 }).map((_, index) => (
+              <button
+                key={index}
+                type="button"
+                className={clsx(
+                  styles["carousel-dot"],
+                  index === currentIndex && styles["carousel-dot--active"],
+                )}
+                onClick={() => setCurrentIndex(index)}
+                aria-label={`Go to item ${index + 1}`}
+              />
+            ))}
+          </div>
+        )}
+        {callToAction && (
+          <div
+            className={clsx(
+              "d-flex",
+              "justify-content-center",
+              "mt-4",
+              styles["carousel-call-to-action"],
+            )}
+          >
+            <Button
+              ariaLabel={callToAction.label}
+              type="button"
+              variant="secondary"
+              onClick={() => (window.location.href = callToAction.href)}
+            >
+              {callToAction.label}
+            </Button>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/content/base/strings.json
+++ b/src/content/base/strings.json
@@ -1,0 +1,3 @@
+{
+  "title": "Analysis for Action"
+}

--- a/src/content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/carousel.json
+++ b/src/content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/carousel.json
@@ -1,0 +1,73 @@
+{
+  "title": "More Resources",
+  "subtitle": "Recommended under the theme Mortality Analysis",
+  "items": [
+    {
+      "id": "3d6f1e5e-420c-4eb1-b3bc-ff625d5663d0",
+      "link": {
+        "href": "/",
+        "label": "Data Visualisation for Public Health"
+      },
+      "subTitle": "Implementing real-time surveillance and response tools.",
+      "readingTime": "3 min",
+      "tags": [
+        {
+          "id": "9a869f8d-df19-43e3-82f3-bd7712f56141",
+          "title": "Mortality Analysis",
+          "type": "secondary"
+        },
+        {
+          "id": "c0d42aa0-4f5c-4b94-b25b-548bc9d84ae5",
+          "title": "Beginner",
+          "type": "gray"
+        }
+      ]
+    },
+    {
+      "id": "a67268d8-4a62-47f7-a952-aa46a5409f0c",
+      "link": {
+        "href": "/",
+        "label": "Data Visualisation & Statistics Globally"
+      },
+      "subTitle": "Leveraging existing administrative datasets to monitor trends.",
+      "readingTime": "5 min",
+      "tags": [
+        {
+          "id": "9a869f8d-df19-43e3-82f3-bd7712f56141",
+          "title": "Mortality Analysis",
+          "type": "secondary"
+        },
+        {
+          "id": "c0d42aa0-4f5c-4b94-b25b-548bc9d84ae5",
+          "title": "Beginner",
+          "type": "gray"
+        }
+      ]
+    },
+    {
+      "id": "b2cc99cf-e15f-4714-a2ce-b62e3de9d0d8",
+      "link": {
+        "href": "/",
+        "label": "Operational Planning and Priority-Setting"
+      },
+      "subTitle": "Coordinating efforts with global partners to support Nepal’s public health response.",
+      "readingTime": "9 min",
+      "tags": [
+        {
+          "id": "9a869f8d-df19-43e3-82f3-bd7712f56141",
+          "title": "Mortality Analysis",
+          "type": "secondary"
+        },
+        {
+          "id": "c0d42aa0-4f5c-4b94-b25b-548bc9d84ae5",
+          "title": "Beginner",
+          "type": "gray"
+        }
+      ]
+    }
+  ],
+  "callToAction": {
+    "label": "All learning resources",
+    "href": "/"
+  }
+}

--- a/src/content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/carousel.json
+++ b/src/content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/carousel.json
@@ -1,4 +1,5 @@
 {
+  "type": "CardUnit",
   "title": "More Resources",
   "subtitle": "Recommended under the theme Mortality Analysis",
   "items": [
@@ -69,5 +70,6 @@
   "callToAction": {
     "label": "All learning resources",
     "href": "/"
-  }
+  },
+  "showNavigation": false
 }

--- a/src/content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/header.json
+++ b/src/content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/header.json
@@ -1,0 +1,32 @@
+{
+  "title": "Introduction to Mortality Analysis",
+  "breadcrumbs": {
+    "items": [
+      {
+        "href": "/",
+        "label": "Home",
+        "id": "0c6dd168-38da-4a09-b62c-971490cb80b4"
+      },
+      {
+        "href": "/",
+        "label": "Learning Resources",
+        "id": "ff2c92ba-35db-4c63-91fb-1c7f5075c15b"
+      },
+      {
+        "href": "/",
+        "label": "Data Analysis",
+        "id": "a8aead7c-4748-4c37-961d-caa64ff6558b"
+      },
+      {
+        "href": "/learning-resources/data-analysis/epidemiological-analysis",
+        "label": "Epidemiological Analysis",
+        "id": "819cf680-7200-4bb0-9cc6-364b86f7bff1"
+      },
+      {
+        "href": "/",
+        "label": "Introduction to Mortality Analysis",
+        "id": "819cf680-7200-4bb0-9cc6-364b86f7bff1"
+      }
+    ]
+  }
+}

--- a/src/content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json
+++ b/src/content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json
@@ -4,7 +4,7 @@
     {
       "id": "8c726a8f-3084-4660-bd45-71a92108ea3e",
       "link": {
-        "href": "/",
+        "href": "/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis",
         "label": "Introduction to Mortality Analysis"
       },
       "subTitle": "Introduction to principles and practices of mortality analysis.",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,15 +1,21 @@
 ---
 // Components
-import { Footer } from "../components/Footer/Footer";
-import { NavBar } from "../components/NavBar/NavBar";
+import { Footer } from "@components/Footer/Footer";
+import { NavBar } from "@components/NavBar/NavBar";
 
 // Content
-import footerData from "../content/base/footerData.json";
-import navBarData from "../content/base/navBarData.json";
+import strings from "@content/base/strings.json";
+import footerData from "@content/base/footerData.json";
+import navBarData from "@content/base/navBarData.json";
 
 // Css and fonts
-import "../styles/index.scss";
+import "@styles/index.scss";
 import "@fontsource-variable/open-sans";
+
+interface Props {
+  title?: string;
+}
+const { title } = Astro.props;
 ---
 
 <html lang="en">
@@ -20,9 +26,9 @@ import "@fontsource-variable/open-sans";
     <meta name="generator" content={Astro.generator} />
     <script>
       // Astro bundles and processes this automatically
-      import "../styles/bootstrap-5.3.8/dist/js/bootstrap.js";
+      import "@styles/bootstrap-5.3.8/dist/js/bootstrap.js";
     </script>
-    <title>Data Analysis</title>
+    <title>{title ? `${strings.title} | ${title}` : strings.title}</title>
   </head>
   <body>
     <header>

--- a/src/pages/learning-resources/data-analysis/epidemiological-analysis/index.astro
+++ b/src/pages/learning-resources/data-analysis/epidemiological-analysis/index.astro
@@ -13,7 +13,7 @@ import headerData from "@content/learning-resources/data-analysis/epidemiologica
 import unitBlockData from "@content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json";
 ---
 
-<BaseLayout>
+<BaseLayout title={headerData.title}>
   <main>
     <Header {...headerData} />
     <UnitBlock {...unitBlockData as UnitBlockProps} />

--- a/src/pages/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/index.astro
+++ b/src/pages/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/index.astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "@layouts/BaseLayout.astro";
+
+// Interfaces
+// import type { UnitBlockProps } from "@components/Core/UnitBlock/UnitBlock.interface";
+
+// Components
+import { Header } from "@components/Core/Header/Header";
+// import { UnitBlock } from "@components/Core/UnitBlock/UnitBlock";
+
+// Content
+import headerData from "@content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/header.json";
+// import unitBlockData from "@content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json";
+---
+
+<BaseLayout>
+  <main>
+    <Header {...headerData} />
+    <!-- <UnitBlock {...unitBlockData as UnitBlockProps} /> -->
+  </main>
+</BaseLayout>

--- a/src/pages/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/index.astro
+++ b/src/pages/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/index.astro
@@ -13,7 +13,7 @@ import headerData from "@content/learning-resources/data-analysis/epidemiologica
 // import unitBlockData from "@content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json";
 ---
 
-<BaseLayout>
+<BaseLayout title={headerData.title}>
   <main>
     <Header {...headerData} />
     <!-- <UnitBlock {...unitBlockData as UnitBlockProps} /> -->

--- a/src/pages/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/index.astro
+++ b/src/pages/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/index.astro
@@ -2,13 +2,15 @@
 import BaseLayout from "@layouts/BaseLayout.astro";
 
 // Interfaces
-// import type { UnitBlockProps } from "@components/Core/UnitBlock/UnitBlock.interface";
+import type { CarouselProps } from "@components/Core/Carousel/Carousel.interface";
 
 // Components
+import { Carousel } from "@components/Core/Carousel/Carousel";
 import { Header } from "@components/Core/Header/Header";
 // import { UnitBlock } from "@components/Core/UnitBlock/UnitBlock";
 
 // Content
+import carouselData from "@content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/carousel.json";
 import headerData from "@content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/header.json";
 // import unitBlockData from "@content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json";
 ---
@@ -16,6 +18,6 @@ import headerData from "@content/learning-resources/data-analysis/epidemiologica
 <BaseLayout title={headerData.title}>
   <main>
     <Header {...headerData} />
-    <!-- <UnitBlock {...unitBlockData as UnitBlockProps} /> -->
+    <Carousel {...carouselData as CarouselProps} />
   </main>
 </BaseLayout>


### PR DESCRIPTION
[ONSPPT-158](https://anddigitaltransformation.atlassian.net/browse/ONSPPT-158) Assemble Page: Mortality Analysis Content Pages
Further fixes required to carousel and still need another component to add into the overview page.

- Updated `src/components/Core/Carousel/...` files to use new aliasing and make minor fixes
- Added `src/content/base/strings.json` to load strings for page title
- Added `src/content/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/...` files for content
- Updated `src/content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json` to make links work from other pages
- Updated `src/layouts/BaseLayout.astro` to use new aliasing and add title as an optional prop so we can set this per page
- Updated `src/pages/learning-resources/data-analysis/epidemiological-analysis/index.astro` to set page title using the new prop
- Added `src/pages/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/index.astro` page