### PR TITLE
Onsppt 211 cloudfront cant handle folder requests

### DIFF
--- a/iac/appendRequest.js
+++ b/iac/appendRequest.js
@@ -1,7 +1,6 @@
 /*
 Appends index.html to request uri so astro static site folder structure can be used for navigation
 */
-
 function handler(event) {
   var request = event.request;
   var uri = request.uri;

--- a/iac/appendRequest.js
+++ b/iac/appendRequest.js
@@ -1,0 +1,19 @@
+/*
+Appends index.html to request uri so astro static site folder structure can be used for navigation
+*/
+
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  // Check whether the URI is missing a file name.
+  if (uri.endsWith("/")) {
+    request.uri += "index.html";
+  }
+  // Check whether the URI is missing a file extension.
+  else if (!uri.includes(".")) {
+    request.uri += "/index.html";
+  }
+
+  return request;
+}

--- a/iac/cloudfront/main.tf
+++ b/iac/cloudfront/main.tf
@@ -18,7 +18,7 @@ resource "aws_cloudfront_distribution" "aws_cloudfront_distribution" {
 
   enabled             = var.distribution_enabled
   comment             = var.distribution_name
-  default_root_object = "index.html"
+  default_root_object = var.default_root_object
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]

--- a/iac/cloudfront/main.tf
+++ b/iac/cloudfront/main.tf
@@ -37,6 +37,14 @@ resource "aws_cloudfront_distribution" "aws_cloudfront_distribution" {
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
+
+    dynamic "function_association" {
+      for_each = var.function_association
+      content {
+        event_type   = function_association.value.event_type
+        function_arn = function_association.value.function_arn
+      }
+    }
   }
 
   price_class = "PriceClass_100"

--- a/iac/cloudfront/variables.tf
+++ b/iac/cloudfront/variables.tf
@@ -8,6 +8,12 @@ variable "bucket_regional_domain_name" {
   type        = string
 }
 
+variable "default_root_object" {
+  description = "Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL"
+  type        = string
+  default     = null
+}
+
 variable "distribution_enabled" {
   description = "Whether the distribution is enabled to accept end user requests for content."
   type        = bool

--- a/iac/cloudfront/variables.tf
+++ b/iac/cloudfront/variables.tf
@@ -32,15 +32,3 @@ variable "function_association" {
   }))
   default = []
 }
-
-
-# variable "function_association_event_type" {
-#   description = "Specific event to trigger this function. Valid values: `viewer-request` or `viewer-response`."
-#   type        = bool
-# }
-
-# variable "function_association_function_arn" {
-#   description = "ARN of the CloudFront function to be triggered per event."
-#   type        = string
-#   default     = null
-# }

--- a/iac/cloudfront/variables.tf
+++ b/iac/cloudfront/variables.tf
@@ -23,3 +23,24 @@ variable "distribution_name" {
   description = "The name of the distribution to show on the AWS console."
   type        = string
 }
+
+variable "function_association" {
+  description = "With CloudFront Functions in Amazon CloudFront, you can write lightweight functions in JavaScript for high-scale, latency-sensitive CDN customizations. You can associate a single function per event type."
+  type = list(object({
+    event_type   = string
+    function_arn = string
+  }))
+  default = []
+}
+
+
+# variable "function_association_event_type" {
+#   description = "Specific event to trigger this function. Valid values: `viewer-request` or `viewer-response`."
+#   type        = bool
+# }
+
+# variable "function_association_function_arn" {
+#   description = "ARN of the CloudFront function to be triggered per event."
+#   type        = string
+#   default     = null
+# }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -15,6 +15,15 @@ terraform {
   required_version = "~> 1.12.2"
 }
 
+# Create cloudfront function required for astro app deployments
+resource "aws_cloudfront_function" "aws_cloudfront_function" {
+  name    = "append-request"
+  runtime = "cloudfront-js-2.0"
+  comment = "Appends index.html to request uri so astro static site folder structure can be used for navigation"
+  publish = true
+  code    = file("${path.module}/appendRequest.js")
+}
+
 # Create bucket for storybook dev
 module "storybook_dev_s3" {
   source                     = "./s3"

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -24,12 +24,14 @@ module "storybook_dev_s3" {
 }
 
 # Set up cloudfront distribution for storybook dev
+# Default root object required for storybook as deployed as SPA
 module "storybook_dev_cloudfront" {
   source                      = "./cloudfront"
   bucket_name                 = module.storybook_dev_s3.id
   bucket_regional_domain_name = module.storybook_dev_s3.bucket_regional_domain_name
   distribution_enabled        = true
   distribution_name           = "Dev storybook"
+  default_root_object         = "index.html"
 }
 
 # Create bucket for storybook main
@@ -41,12 +43,14 @@ module "storybook_main_s3" {
 }
 
 # Set up cloudfront distribution for storybook main
+# Default root object required for storybook as deployed as SPA
 module "storybook_main_cloudfront" {
   source                      = "./cloudfront"
   bucket_name                 = module.storybook_main_s3.id
   bucket_regional_domain_name = module.storybook_main_s3.bucket_regional_domain_name
   distribution_enabled        = true
   distribution_name           = "Main storybook"
+  default_root_object         = "index.html"
 }
 
 # Create bucket for app dev

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -71,12 +71,21 @@ module "app_dev_s3" {
 }
 
 # Set up cloudfront distribution for app dev
+# Function association is enabled to enable astro static site folder based navigation
 module "app_dev_cloudfront" {
   source                      = "./cloudfront"
   bucket_name                 = module.app_dev_s3.id
   bucket_regional_domain_name = module.app_dev_s3.bucket_regional_domain_name
   distribution_enabled        = true
   distribution_name           = "Dev app"
+  function_association = [
+    {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.aws_cloudfront_function.arn
+    }
+  ]
+  # function_association_event_type = "viewer-request"
+  # function_association_function_arn = aws_cloudfront_function.aws_cloudfront_function.arn
 }
 
 # Create bucket for app main
@@ -88,12 +97,17 @@ module "app_main_s3" {
 }
 
 # Set up cloudfront distribution for app main
+# Function association is enabled to enable astro static site folder based navigation
 module "app_main_cloudfront" {
   source                      = "./cloudfront"
   bucket_name                 = module.app_main_s3.id
   bucket_regional_domain_name = module.app_main_s3.bucket_regional_domain_name
   distribution_enabled        = true
   distribution_name           = "Main app"
+  function_association = [{
+    event_type   = "viewer-request"
+    function_arn = aws_cloudfront_function.aws_cloudfront_function.arn
+  }]
 }
 
 # Create iam user for automated deployments via github actions

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -84,8 +84,6 @@ module "app_dev_cloudfront" {
       function_arn = aws_cloudfront_function.aws_cloudfront_function.arn
     }
   ]
-  # function_association_event_type = "viewer-request"
-  # function_association_function_arn = aws_cloudfront_function.aws_cloudfront_function.arn
 }
 
 # Create bucket for app main


### PR DESCRIPTION
[ONSPPT-211](https://anddigitaltransformation.atlassian.net/browse/ONSPPT-211) Cloudfront can't handle folder requests
Fixed issue where we had set up Cloudfront distributions to suit a SPA deployment. This is working OK for Storybook and was working ok when we only had the homepage with the astro app, but didn't work when we moved to a multipage site following the structure of the s3 bucket directories.

- Added `iac/appendRequest.js` which includes a js function to append `index.html` to requests when run by a cloudfront distribution. This ensures astro pages in folders are found when we get a request to e.g. `/learning-resources/data-analysis/epidemiological-analysis`
- Updated `iac/cloudfront/main.tf` to set `default_root_object` and `function_association` conditionally
- Updated `iac/cloudfront/variables.tf` to use new optional `default_root_object` and `function_association` input vars
- Updated `iac/main.tf` to set optional vars based on Cloudfront distribution. Storybook distributions require `default_root_object`, app distributions require `function_association` 