### PR TITLE
Onsppt 180 create question bank filter menu organism

### DIFF
--- a/src/components/ListGroup/ListGroup.interface.ts
+++ b/src/components/ListGroup/ListGroup.interface.ts
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from "react";
 import type { FilterItem } from "../../types/FilterItem";
 import type { NavItem } from "../../types/NavItem";
 
@@ -5,6 +6,8 @@ export interface ListGroupChecksProps {
   title?: string;
   checkItems: FilterItem[];
   inverse?: boolean;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  selectedIds?: string[];
 }
 
 export interface ListGroupLinksProps {

--- a/src/components/ListGroup/ListGroup.interface.ts
+++ b/src/components/ListGroup/ListGroup.interface.ts
@@ -6,7 +6,7 @@ export interface ListGroupChecksProps {
   title?: string;
   checkItems: FilterItem[];
   inverse?: boolean;
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: ChangeEvent<HTMLInputElement>;
   selectedIds?: string[];
 }
 

--- a/src/components/ListGroup/ListGroup.interface.ts
+++ b/src/components/ListGroup/ListGroup.interface.ts
@@ -6,7 +6,7 @@ export interface ListGroupChecksProps {
   title?: string;
   checkItems: FilterItem[];
   inverse?: boolean;
-  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void; // eslint-disable-line no-unused-vars
   selectedIds?: string[];
 }
 

--- a/src/components/ListGroup/ListGroup.interface.ts
+++ b/src/components/ListGroup/ListGroup.interface.ts
@@ -6,7 +6,7 @@ export interface ListGroupChecksProps {
   title?: string;
   checkItems: FilterItem[];
   inverse?: boolean;
-  onChange?: ChangeEvent<HTMLInputElement>;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   selectedIds?: string[];
 }
 

--- a/src/components/ListGroup/ListGroup.tsx
+++ b/src/components/ListGroup/ListGroup.tsx
@@ -29,7 +29,7 @@ export const ListGroupChecks: FC<ListGroupChecksProps> = (props) => {
                   type="checkbox"
                   id={item.id}
                   onChange={props.onChange}
-                  checked={!!isSelected} // convert to boolean explicitly
+                  checked={isSelected}
                 />
                 <label className={clsx("form-check-label")} htmlFor={item.id}>
                   {item.label}

--- a/src/components/ListGroup/ListGroup.tsx
+++ b/src/components/ListGroup/ListGroup.tsx
@@ -21,8 +21,9 @@ export const ListGroupChecks: FC<ListGroupChecksProps> = (props) => {
               <input
                 className={clsx("form-check-input")}
                 type="checkbox"
-                value=""
                 id={item.id}
+                onChange={props.onChange}
+                checked={props.selectedIds?.includes(item.id) ?? false}
               />
               <label className={clsx("form-check-label")} htmlFor={item.id}>
                 {item.label}

--- a/src/components/ListGroup/ListGroup.tsx
+++ b/src/components/ListGroup/ListGroup.tsx
@@ -15,22 +15,29 @@ export const ListGroupChecks: FC<ListGroupChecksProps> = (props) => {
         <p className={clsx("text-primary", "fw-bold")}>{props.title}</p>
       )}
       <ul className={clsx("list-group", "list-group-flush")}>
-        {props.checkItems.map((item, index) => (
-          <li className={clsx("list-group-item")} key={`listGroupItem${index}`}>
-            <div className={clsx("form-check")}>
-              <input
-                className={clsx("form-check-input")}
-                type="checkbox"
-                id={item.id}
-                onChange={props.onChange}
-                checked={props.selectedIds?.includes(item.id) ?? false}
-              />
-              <label className={clsx("form-check-label")} htmlFor={item.id}>
-                {item.label}
-              </label>
-            </div>
-          </li>
-        ))}
+        {props.checkItems.map((item, index) => {
+          const isSelected =
+            props.selectedIds && props.selectedIds.includes(item.id);
+          return (
+            <li
+              className={clsx("list-group-item")}
+              key={`listGroupItem${index}`}
+            >
+              <div className={clsx("form-check")}>
+                <input
+                  className={clsx("form-check-input")}
+                  type="checkbox"
+                  id={item.id}
+                  onChange={props.onChange}
+                  checked={!!isSelected} // convert to boolean explicitly
+                />
+                <label className={clsx("form-check-label")} htmlFor={item.id}>
+                  {item.label}
+                </label>
+              </div>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/components/ListGroup/ListGroupChecks.stories.tsx
+++ b/src/components/ListGroup/ListGroupChecks.stories.tsx
@@ -1,8 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ListGroupChecks } from "./ListGroup";
-import type { ListGroupChecksProps } from "./ListGroup.interface";
-
+import listGroupCheckData from "@content/listGroupCheckData.json";
 const meta = {
   argTypes: {
     checkItems: {
@@ -26,30 +25,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const listGroupChecksProps: ListGroupChecksProps = {
-  title: "Theme",
-  checkItems: [
-    { label: "Demographic Information", id: "demographic-information" },
-    { label: "Carer Specific", id: "carer-specific" },
-    { label: "General Health", id: "general-health" },
-    { label: "COVID-19 Symptoms", id: "covid-19-symptoms" },
-    { label: "Mental Health and Wellbeing", id: "mental-health-and-wellbeing" },
-    {
-      label: "Economic and Employment Impact",
-      id: "economic-and-employment-impact",
-    },
-    {
-      label: "Social and Lifestyle Impacts",
-      id: "social-and-lifestyle-impacts",
-    },
-    { label: "Travel", id: "travel" },
-    { label: "Policy and Compliance", id: "policy-and-compliance" },
-    { label: "Students", id: "students" },
-  ],
-  inverse: false,
-};
-
 export const ListGroupChecksStory = {
   name: "Checkboxes",
-  args: listGroupChecksProps,
+  args: listGroupCheckData,
 } satisfies Story;

--- a/src/components/ListGroup/ListGroupChecks.stories.tsx
+++ b/src/components/ListGroup/ListGroupChecks.stories.tsx
@@ -53,14 +53,3 @@ export const ListGroupChecksStory = {
   name: "Checkboxes",
   args: listGroupChecksProps,
 } satisfies Story;
-
-// export const ListGroupChecksInverseStory = {
-//   name: "Checkboxes inverse",
-//   args: {
-//     ...listGroupChecksProps,
-//     inverse: true,
-//   },
-//   globals: {
-//     backgrounds: { value: "dark" },
-//   },
-// } satisfies Story;

--- a/src/components/QuestionBank/Explainer/Explainer.module.scss
+++ b/src/components/QuestionBank/Explainer/Explainer.module.scss
@@ -1,5 +1,0 @@
-@use "../../../styles/global/variables" as *;
-
-.explainer-bg {
-  background-color: $color-surface-subtle;
-}

--- a/src/components/QuestionBank/Explainer/Explainer.stories.tsx
+++ b/src/components/QuestionBank/Explainer/Explainer.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import DOMPurify from "dompurify";
 
-import markdownContent from "../../../content/QuestionBank/explainer.md?raw";
-import { parseMarkdown } from "../../../helpers/parseMarkdown";
+import markdownContent from "@content/QuestionBank/explainer.md?raw";
+import { parseMarkdown } from "@src/helpers/parseMarkdown";
 import { Explainer } from "./Explainer";
 import type { ExplainerProps } from "./Explainer.interface";
 

--- a/src/components/QuestionBank/Explainer/Explainer.tsx
+++ b/src/components/QuestionBank/Explainer/Explainer.tsx
@@ -3,12 +3,11 @@ import type { FC } from "react";
 
 import { TextModule } from "../../TextModule/TextModule";
 import type { ExplainerProps } from "./Explainer.interface";
-import styles from "./Explainer.module.scss";
 
 // Renders input `htmlContent` using the `TextModule` component
 export const Explainer: FC<ExplainerProps> = (props) => {
   return (
-    <div className={clsx("w-100", styles["explainer-bg"])}>
+    <div className={clsx("w-100")}>
       <div className={clsx("container-lg", "py-4")}>
         <TextModule {...props} />
       </div>

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.interface.ts
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.interface.ts
@@ -1,7 +1,9 @@
 import type { ListGroupChecksProps } from "../../ListGroup/ListGroup.interface";
+import type { ExplainerProps } from "../Explainer/Explainer.interface";
 import type { QuestionBlockProps } from "../QuestionBlock/QuestionBlock.interface";
 
 export interface FilterMenuProps {
+  explainerProps: ExplainerProps;
   listGroupChecksProps: ListGroupChecksProps;
   questionBlockListProps: QuestionBlockProps[];
 }

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.interface.ts
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.interface.ts
@@ -1,1 +1,7 @@
-export interface FilterMenuProps {}
+import type { ListGroupChecksProps } from "../../ListGroup/ListGroup.interface";
+import type { QuestionBlockProps } from "../QuestionBlock/QuestionBlock.interface";
+
+export interface FilterMenuProps {
+  listGroupChecksProps: ListGroupChecksProps;
+  questionBlockListProps: QuestionBlockProps[];
+}

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.interface.ts
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.interface.ts
@@ -1,0 +1,1 @@
+export interface FilterMenuProps {}

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.module.scss
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.module.scss
@@ -1,0 +1,5 @@
+@use "../../../styles/global/tokens" as *;
+
+.filter-menu__container {
+  background-color: $color-brand-secondary-100;
+}

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
@@ -29,7 +29,11 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  argTypes: {},
+  argTypes: {
+    explainerProps: { table: { disable: true } },
+    listGroupChecksProps: { table: { disable: true } },
+    questionBlockListProps: { table: { disable: true } },
+  },
 } satisfies Meta<typeof FilterMenu>;
 
 export default meta;

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FilterMenu } from "./FilterMenu";
+
+const meta = {
+  component: FilterMenu,
+  title: "Organisms/QuestionBank/FilterMenu",
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {},
+} satisfies Meta<typeof FilterMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FilterMenuStory = {
+  name: "FilterMenu",
+} satisfies Story;

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
@@ -1,5 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { FilterMenu } from "./FilterMenu";
+import DOMPurify from "dompurify";
+import { v4 as uuidv4 } from "uuid";
+
+import ageQ1MdContent from "@content/QuestionBank/questions/age/1.md?raw";
+import ageQ2MdContent from "@content/QuestionBank/questions/age/2.md?raw";
+import ageQ3MdContent from "@content/QuestionBank/questions/age/3.md?raw";
+import ageQ4MdContent from "@content/QuestionBank/questions/age/4.md?raw";
+import ageQ5MdContent from "@content/QuestionBank/questions/age/5.md?raw";
+import ethnicityQ1MdContent from "@content/QuestionBank/questions/ethnicity/1.md?raw";
+import ethnicityQ2MdContent from "@content/QuestionBank/questions/ethnicity/2.md?raw";
+import travelQ1MdContent from "@content/QuestionBank/questions/travel/1.md?raw";
+import travelQ2MdContent from "@content/QuestionBank/questions/travel/2.md?raw";
+
+import { parseMarkdown } from "@src/helpers/parseMarkdown";
+import { FilterMenu } from "@components/QuestionBank/FilterMenu/FilterMenu";
+import type { FilterMenuProps } from "@components/QuestionBank/FilterMenu/FilterMenu.interface";
+import listGroupCheckData from "@content/listGroupCheckData.json";
+import type { QuestionBlockProps } from "@components/QuestionBank/QuestionBlock/QuestionBlock.interface";
+import type { TagData } from "@src/types/TagData";
 
 const meta = {
   component: FilterMenu,
@@ -13,6 +31,68 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+async function createQuestionBlock(
+  title: string,
+  tags: Omit<TagData, "id">[],
+  markdownContents: string[],
+): Promise<QuestionBlockProps> {
+  const htmlContents = await Promise.all(markdownContents.map(parseMarkdown));
+
+  return {
+    id: uuidv4(),
+    title,
+    tags: tags.map((tag) => ({
+      id: uuidv4(),
+      title: tag.title,
+      type: tag.type,
+    })),
+    questions: htmlContents.map((htmlContent) => ({
+      id: uuidv4(),
+      htmlContent: DOMPurify.sanitize(htmlContent),
+    })),
+  };
+}
+const ageQuestionBlock = await createQuestionBlock(
+  "Demographic information",
+  [{ title: "Age", type: "secondary" }],
+  [
+    ageQ1MdContent,
+    ageQ2MdContent,
+    ageQ3MdContent,
+    ageQ4MdContent,
+    ageQ5MdContent,
+  ],
+);
+
+const ethnicityQuestionBlock = await createQuestionBlock(
+  "Demographic information",
+  [{ title: "Ethnicity", type: "secondary" }],
+  [ethnicityQ1MdContent, ethnicityQ2MdContent],
+);
+
+const travelQuestionBlock = await createQuestionBlock(
+  "Travel",
+  [
+    {
+      title: "Frequency and purpose of travel (business, leisure, family)",
+      type: "secondary",
+    },
+  ],
+  [travelQ1MdContent, travelQ2MdContent],
+);
+
+const questionBlockList: QuestionBlockProps[] = [
+  ageQuestionBlock,
+  ethnicityQuestionBlock,
+  travelQuestionBlock,
+];
+
+const filterMenuProps: FilterMenuProps = {
+  listGroupChecksProps: listGroupCheckData,
+  questionBlockListProps: questionBlockList,
+};
+
 export const FilterMenuStory = {
   name: "FilterMenu",
+  args: filterMenuProps,
 } satisfies Story;

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.stories.tsx
@@ -7,17 +7,21 @@ import ageQ2MdContent from "@content/QuestionBank/questions/age/2.md?raw";
 import ageQ3MdContent from "@content/QuestionBank/questions/age/3.md?raw";
 import ageQ4MdContent from "@content/QuestionBank/questions/age/4.md?raw";
 import ageQ5MdContent from "@content/QuestionBank/questions/age/5.md?raw";
+
 import ethnicityQ1MdContent from "@content/QuestionBank/questions/ethnicity/1.md?raw";
 import ethnicityQ2MdContent from "@content/QuestionBank/questions/ethnicity/2.md?raw";
+
 import travelQ1MdContent from "@content/QuestionBank/questions/travel/1.md?raw";
 import travelQ2MdContent from "@content/QuestionBank/questions/travel/2.md?raw";
+
+import explainerMdContent from "@content/QuestionBank/explainer.md?raw";
 
 import { parseMarkdown } from "@src/helpers/parseMarkdown";
 import { FilterMenu } from "@components/QuestionBank/FilterMenu/FilterMenu";
 import type { FilterMenuProps } from "@components/QuestionBank/FilterMenu/FilterMenu.interface";
-import listGroupCheckData from "@content/listGroupCheckData.json";
 import type { QuestionBlockProps } from "@components/QuestionBank/QuestionBlock/QuestionBlock.interface";
 import type { TagData } from "@src/types/TagData";
+import type { ExplainerProps } from "../Explainer/Explainer.interface";
 
 const meta = {
   component: FilterMenu,
@@ -31,18 +35,17 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-async function createQuestionBlock(
+function createQuestionBlock(
+  id: string,
   title: string,
-  tags: Omit<TagData, "id">[],
-  markdownContents: string[],
-): Promise<QuestionBlockProps> {
-  const htmlContents = await Promise.all(markdownContents.map(parseMarkdown));
-
+  tags: TagData[],
+  htmlContents: string[],
+) {
   return {
-    id: uuidv4(),
+    id,
     title,
     tags: tags.map((tag) => ({
-      id: uuidv4(),
+      id: tag.id,
       title: tag.title,
       type: tag.type,
     })),
@@ -52,33 +55,68 @@ async function createQuestionBlock(
     })),
   };
 }
-const ageQuestionBlock = await createQuestionBlock(
-  "Demographic information",
-  [{ title: "Age", type: "secondary" }],
+
+const ageQ1HtmlContent = await parseMarkdown(ageQ1MdContent);
+const ageQ2HtmlContent = await parseMarkdown(ageQ2MdContent);
+const ageQ3HtmlContent = await parseMarkdown(ageQ3MdContent);
+const ageQ4HtmlContent = await parseMarkdown(ageQ4MdContent);
+const ageQ5HtmlContent = await parseMarkdown(ageQ5MdContent);
+
+const ethnicityQ1HtmlContent = await parseMarkdown(ethnicityQ1MdContent);
+const ethnicityQ2HtmlContent = await parseMarkdown(ethnicityQ2MdContent);
+
+const travelQ1HtmlContent = await parseMarkdown(travelQ1MdContent);
+const travelQ2HtmlContent = await parseMarkdown(travelQ2MdContent);
+
+// Checkbox and QuestionBlock must have common ID and label
+const themeLabel1 = "Demographic Information";
+const themeId1 = uuidv4();
+const themeLabel2 = "Travel";
+const themeId2 = uuidv4();
+
+// Construct props for ListGroupCheck component
+const listGroupCheckData = {
+  title: "Theme",
+  checkItems: [
+    { label: themeLabel1, id: themeId1 },
+    { label: themeLabel2, id: themeId2 },
+  ],
+  inverse: false,
+};
+
+// Construct props for QuestionBlock component
+const ageQuestionBlock = createQuestionBlock(
+  themeId1,
+  "Age",
+  [{ id: themeId1, title: themeLabel1, type: "secondary" }],
   [
-    ageQ1MdContent,
-    ageQ2MdContent,
-    ageQ3MdContent,
-    ageQ4MdContent,
-    ageQ5MdContent,
+    ageQ1HtmlContent,
+    ageQ2HtmlContent,
+    ageQ3HtmlContent,
+    ageQ4HtmlContent,
+    ageQ5HtmlContent,
   ],
 );
 
-const ethnicityQuestionBlock = await createQuestionBlock(
-  "Demographic information",
-  [{ title: "Ethnicity", type: "secondary" }],
-  [ethnicityQ1MdContent, ethnicityQ2MdContent],
+const ethnicityQuestionBlock = createQuestionBlock(
+  themeId1,
+  "Ethnicity",
+
+  [{ id: themeId1, title: themeLabel1, type: "secondary" }],
+  [ethnicityQ1HtmlContent, ethnicityQ2HtmlContent],
 );
 
-const travelQuestionBlock = await createQuestionBlock(
-  "Travel",
+const travelQuestionBlock = createQuestionBlock(
+  themeId2,
+  "Frequency and purpose of travel (business, leisure, family)",
   [
     {
-      title: "Frequency and purpose of travel (business, leisure, family)",
+      id: themeId2,
+      title: themeLabel2,
       type: "secondary",
     },
   ],
-  [travelQ1MdContent, travelQ2MdContent],
+  [travelQ1HtmlContent, travelQ2HtmlContent],
 );
 
 const questionBlockList: QuestionBlockProps[] = [
@@ -87,7 +125,16 @@ const questionBlockList: QuestionBlockProps[] = [
   travelQuestionBlock,
 ];
 
+// Construct props for Explainer component
+const htmlContent = await parseMarkdown(explainerMdContent);
+
+const explainerProps: ExplainerProps = {
+  htmlContent: DOMPurify.sanitize(htmlContent),
+};
+
+// Bring all the props together for FilterMenu component
 const filterMenuProps: FilterMenuProps = {
+  explainerProps: explainerProps,
   listGroupChecksProps: listGroupCheckData,
   questionBlockListProps: questionBlockList,
 };

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
@@ -1,17 +1,63 @@
 import clsx from "clsx";
-import type { FC } from "react";
+import { useState, type FC } from "react";
 
+import type { FilterMenuProps } from "@components/QuestionBank/FilterMenu/FilterMenu.interface";
+import { ListGroupChecks } from "@components/ListGroup/ListGroup";
+import { QuestionBlock } from "@components/QuestionBank/QuestionBlock/QuestionBlock";
 import styles from "./FilterMenu.module.scss";
-import type { FilterMenuProps } from "./FilterMenu.interface";
-import { ListGroupChecks } from "../../ListGroup/ListGroup";
-import { QuestionBlock } from "../QuestionBlock/QuestionBlock";
+import { Explainer } from "../Explainer/Explainer";
 
-// Renders input `htmlContent` using the `TextModule` component
 export const FilterMenu: FC<FilterMenuProps> = (props) => {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const onCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, checked } = event.target;
+
+    setSelectedIds((currentSelection) => {
+      if (checked) {
+        if (currentSelection.includes(id)) {
+          return currentSelection;
+        }
+        return [...currentSelection, id];
+      } else {
+        return currentSelection.filter((selectedId) => selectedId !== id);
+      }
+    });
+  };
+
+  const hasSelectedIds = selectedIds.length > 0;
+
+  const filteredQuestionBlocks = hasSelectedIds
+    ? props.questionBlockListProps.filter((block) =>
+        selectedIds.includes(block.id),
+      )
+    : props.questionBlockListProps;
+
   return (
-    <div>
-      <ListGroupChecks {...props.listGroupChecksProps} />
-      <QuestionBlock {...props.questionBlockProps} />
+    <div className={clsx("w-100", styles["filter-menu__container"])}>
+      <div className={clsx("container-lg", "py-4", "p-lg-5")}>
+        <div className={clsx("row")}>
+          <div className={clsx("col")}>
+            <Explainer {...props.explainerProps} />
+          </div>
+        </div>
+        <div className={clsx("row", "gap-lg-4", "my-lg-4")}>
+          <div className={clsx("col", "col-md-auto", "mb-4", "mb-lg-0")}>
+            <ListGroupChecks
+              {...props.listGroupChecksProps}
+              selectedIds={selectedIds}
+              onChange={onCheckboxChange}
+            />
+          </div>
+          <div
+            className={clsx("col", "d-flex", "flex-column", "gap-4", "w-100")}
+          >
+            {filteredQuestionBlocks.map((questionBlock, index) => {
+              return <QuestionBlock key={index} {...questionBlock} />;
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
@@ -1,0 +1,10 @@
+import clsx from "clsx";
+import type { FC } from "react";
+
+import styles from "./FilterMenu.module.scss";
+import type { FilterMenuProps } from "./FilterMenu.interface";
+
+// Renders input `htmlContent` using the `TextModule` component
+export const FilterMenu: FC<FilterMenuProps> = (props) => {
+  return <div>HELLO</div>;
+};

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
@@ -3,8 +3,15 @@ import type { FC } from "react";
 
 import styles from "./FilterMenu.module.scss";
 import type { FilterMenuProps } from "./FilterMenu.interface";
+import { ListGroupChecks } from "../../ListGroup/ListGroup";
+import { QuestionBlock } from "../QuestionBlock/QuestionBlock";
 
 // Renders input `htmlContent` using the `TextModule` component
 export const FilterMenu: FC<FilterMenuProps> = (props) => {
-  return <div>HELLO</div>;
+  return (
+    <div>
+      <ListGroupChecks {...props.listGroupChecksProps} />
+      <QuestionBlock {...props.questionBlockProps} />
+    </div>
+  );
 };

--- a/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
+++ b/src/components/QuestionBank/FilterMenu/FilterMenu.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useState, type FC } from "react";
+import { useState, type ChangeEvent, type FC } from "react";
 
 import type { FilterMenuProps } from "@components/QuestionBank/FilterMenu/FilterMenu.interface";
 import { ListGroupChecks } from "@components/ListGroup/ListGroup";
@@ -10,7 +10,7 @@ import { Explainer } from "../Explainer/Explainer";
 export const FilterMenu: FC<FilterMenuProps> = (props) => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
-  const onCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onCheckboxChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { id, checked } = event.target;
 
     setSelectedIds((currentSelection) => {

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.module.scss
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.module.scss
@@ -1,7 +1,7 @@
 @use "../../../styles/global/tokens" as *;
 @use "../../../styles/global/variables" as *;
 
-.border-color {
+.question-block__container {
   background-color: $color-grey-100;
   border-color: $color-brand-secondary-200 !important;
 }

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.module.scss
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.module.scss
@@ -2,7 +2,7 @@
 @use "../../../styles/global/variables" as *;
 
 .border-color {
-  // background-color: $color-surface-subtle;
+  background-color: $color-grey-100;
   border-color: $color-brand-secondary-200 !important;
 }
 

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.stories.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.stories.tsx
@@ -2,11 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react";
 import DOMPurify from "dompurify";
 import { v4 as uuidv4 } from "uuid";
 
-import q1MdContent from "../../../content/QuestionBank/questions/age/1.md?raw";
-import q2MdContent from "../../../content/QuestionBank/questions/age/2.md?raw";
-import q3MdContent from "../../../content/QuestionBank/questions/age/3.md?raw";
-import q4MdContent from "../../../content/QuestionBank/questions/age/4.md?raw";
-import q5MdContent from "../../../content/QuestionBank/questions/age/5.md?raw";
+import q1MdContent from "@content/QuestionBank/questions/age/1.md?raw";
+import q2MdContent from "@content/QuestionBank/questions/age/2.md?raw";
+import q3MdContent from "@content/QuestionBank/questions/age/3.md?raw";
+import q4MdContent from "@content/QuestionBank/questions/age/4.md?raw";
+import q5MdContent from "@content/QuestionBank/questions/age/5.md?raw";
 import { parseMarkdown } from "../../../helpers/parseMarkdown";
 import { QuestionBlock } from "./QuestionBlock";
 import type { QuestionBlockProps } from "./QuestionBlock.interface";

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
@@ -8,7 +8,14 @@ import styles from "./QuestionBlock.module.scss";
 
 export const QuestionBlock: FC<QuestionBlockProps> = (props) => {
   return (
-    <div className={clsx("p-4", "border", "rounded", styles["border-color"])}>
+    <div
+      className={clsx(
+        "p-4",
+        "border",
+        "rounded",
+        styles["question-block__container"],
+      )}
+    >
       <div className={clsx("d-inline-flex", "pt-4", "pb-2")}>
         {props.tags.map((tag) => (
           <Tag {...tag} />

--- a/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
+++ b/src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx
@@ -8,15 +8,7 @@ import styles from "./QuestionBlock.module.scss";
 
 export const QuestionBlock: FC<QuestionBlockProps> = (props) => {
   return (
-    <div
-      className={clsx(
-        "container",
-        "p-4",
-        "border",
-        "rounded",
-        styles["border-color"],
-      )}
-    >
+    <div className={clsx("p-4", "border", "rounded", styles["border-color"])}>
       <div className={clsx("d-inline-flex", "pt-4", "pb-2")}>
         {props.tags.map((tag) => (
           <Tag {...tag} />

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -10,11 +10,10 @@ export const Tag: FC<TagProps> = (props) => {
       className={clsx(
         "badge",
         "rounded-pill",
-        "text-nowrap",
-        "text-truncate",
         styles[`tag-${props.type}`],
         "px-3",
         "py-2",
+        "text-center",
       )}
     >
       {props.title}

--- a/src/content/QuestionBank/questions/ethnicity/1.md
+++ b/src/content/QuestionBank/questions/ethnicity/1.md
@@ -1,0 +1,10 @@
+**1. What is your ethnic group?**
+
+- White
+- Mixed / Multiple ethnic groups
+- Asian / Asian British
+- Black / African / Caribbean / Black British
+- Chinese
+- Arab
+- Other ethnic group
+- Prefer not to say

--- a/src/content/QuestionBank/questions/ethnicity/2.md
+++ b/src/content/QuestionBank/questions/ethnicity/2.md
@@ -1,0 +1,10 @@
+**2. What is your ethnic group? I will read out the options. Please choose one option that best describes your ethnic group or background.**
+
+- White
+- Mixed / Multiple ethnic groups
+- Asian / Asian British
+- Black / African / Caribbean / Black British
+- Chinese
+- Arab
+- Other ethnic group
+- Prefer not to say

--- a/src/content/QuestionBank/questions/travel/1.md
+++ b/src/content/QuestionBank/questions/travel/1.md
@@ -1,0 +1,5 @@
+**1.How well do you understand the requirements that are in place for those arriving in the UK? Would you say you have...**
+
+- Very poor understanding
+- Some but limited understanding
+- Good understanding

--- a/src/content/QuestionBank/questions/travel/2.md
+++ b/src/content/QuestionBank/questions/travel/2.md
@@ -1,0 +1,7 @@
+**2.Overall, how easy of difficult did you find it to follow Coronavirus (COVID-19) regulations during your stay overseas?**
+
+- Very difficult
+- Difficult
+- Neither easy nor difficult
+- Easy
+- Very easy

--- a/src/content/listGroupCheckData.json
+++ b/src/content/listGroupCheckData.json
@@ -1,0 +1,25 @@
+{
+  "title": "Theme",
+  "checkItems": [
+    { "label": "Demographic Information", "id": "demographic-information" },
+    { "label": "Carer Specific", "id": "carer-specific" },
+    { "label": "General Health", "id": "general-health" },
+    { "label": "COVID-19 Symptoms", "id": "covid-19-symptoms" },
+    {
+      "label": "Mental Health and Wellbeing",
+      "id": "mental-health-and-wellbeing"
+    },
+    {
+      "label": "Economic and Employment Impact",
+      "id": "economic-and-employment-impact"
+    },
+    {
+      "label": "Social and Lifestyle Impacts",
+      "id": "social-and-lifestyle-impacts"
+    },
+    { "label": "Travel", "id": "travel" },
+    { "label": "Policy and Compliance", "id": "policy-and-compliance" },
+    { "label": "Students", "id": "students" }
+  ],
+  "inverse": false
+}


### PR DESCRIPTION
### What 
Ticket: https://anddigitaltransformation.atlassian.net/browse/ONSPPT-180
Figma: https://www.figma.com/design/E69gbVRwchC2DBS3sckQyM/PPT-Design-Files?node-id=4240-139780&m=dev

#### Code change

- Modified `src/components/ListGroup/ListGroup.interface.ts` to accept `onChange` and `selectedIds` as optional props for use in trigger events when `FilterMenu` checkboxes that have been selected
- Updated `src/components/ListGroup/ListGroup.tsx` to accept `onChange` function and determine if checkbox is selected on re-renders by react
- Modified `src/components/ListGroup/ListGroupChecks.stories.tsx` to take in `ListGroupCheckData` from `@content` 
- Deleted redundant `src/components/QuestionBank/Explainer/Explainer.module.scss`
- Modified `src/components/QuestionBank/Explainer/Explainer.stories.tsx` to use aliases
- Updated `src/components/QuestionBank/Explainer/Explainer.tsx` to not use redundant class (`Explainer` can be transparent)
- Created `src/components/QuestionBank/FilterMenu/...` files for `FilterMenu` interface, stylesheet, story and component
   - Story defines `createQuestionBlock` for the sake of creating multiple `QuestionBlock` components from various `.md` files
- Updated `src/components/QuestionBank/QuestionBlock/QuestionBlock.module.scss` to define correct `background-color` (off-white instead of transparent) and changed class name
- Updated `src/components/QuestionBank/QuestionBlock/QuestionBlock.stories.tsx` to use aliases
- Updated `src/components/QuestionBank/QuestionBlock/QuestionBlock.tsx` to use the new, more-general class
- Updated `src/components/Tag/Tag.tsx` to remove `text-nowrap` and `text-truncate` which were causing overflow issues in parent components that they were passed to. `text-center` was also add to make mobile view better when tags involved. If we find text does indeed get too long in future, we can just address it then. 
- Created more `src/content/QuestionBank/questions/...` for `ethnicity`, `age` and `travel` which are used as examples in this `FilterMenu` organism

#### Note 
- Currently this is just set up for just `themes` not `subthemes`