### PR TITLE
ONSPPT-215 Fix nav bar so that megamenu doesn't persist

### DIFF
--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -38,54 +38,6 @@ export const NavBar: FC<NavBarProps> = ({
 
   const navRef = useRef<HTMLDivElement>(null);
 
-  const findActiveNavItem = (): NavItem | null => {
-    const currentPath = window.location.pathname;
-
-    for (const item of items) {
-      if (item.href && item.href !== "#" && currentPath === item.href) {
-        return item;
-      }
-
-      if (item.children) {
-        const hasActiveChild = checkChildrenForPath(item.children, currentPath);
-        if (hasActiveChild) {
-          return item;
-        }
-      }
-    }
-
-    for (const item of items) {
-      if (item.children) {
-        const pathSegment = currentPath.split("/")[1];
-        const normalizedLabel = item.label.toLowerCase().replace(/\s+/g, "-");
-        if (pathSegment === normalizedLabel) {
-          return item;
-        }
-      }
-    }
-
-    return null;
-  };
-
-  const checkChildrenForPath = (children: NavItem[], path: string): boolean => {
-    for (const child of children) {
-      if (child.href && child.href !== "#" && path === child.href) {
-        return true;
-      }
-      if (child.children && checkChildrenForPath(child.children, path)) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  useEffect(() => {
-    const activeItem = findActiveNavItem();
-    if (activeItem && !selectedItem) {
-      setSelectedItem(activeItem);
-    }
-  }, []);
-
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
     setSelectedItem(null);


### PR DESCRIPTION
### What 
Ticket: https://anddigitaltransformation.atlassian.net/browse/ONSPPT-215

#### Code changes: 
`src/components/NavBar/NavBar.tsx`
- UseEffect within `NavBar` component fetched the `selectedItem` by seeing what was previously active. Since the `useEffect` was set with `[]`, this fetch-and-set would happen on all page load/ redirect. I don't think this is necessary, and seems to be responsible for the `megamenu` persist
- Removing this also meant we could remove `findActiveNavItem` and `checkChildrenForPath` 

#### Result
`NavBar` functionality on mobile and desktop still works as expected, and the `megamenu` doesn't persist 👍 