### PR TITLE
Megamenu overlaps the content on desktop with box shadow

### DIFF
--- a/src/components/NavBar/NavBar.module.scss
+++ b/src/components/NavBar/NavBar.module.scss
@@ -458,8 +458,9 @@
 }
 
 .desktop-mega-menu {
-  @include media-breakpoint-down(md) {
-    display: none;
+  @include media-breakpoint-up(md) {
+    position: absolute;
+    box-shadow: 0 10px 20px 0 rgba($color-grey-600, 0.1);
   }
 }
 

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -222,7 +222,14 @@ export const NavBar: FC<NavBarProps> = ({
 
       {/* Desktop Mega Menu */}
       {selectedItem && selectedItem.children && (
-        <div className={styles["desktop-mega-menu"]}>
+        <div
+          className={clsx(
+            "w-100",
+            "d-none",
+            "d-lg-block",
+            styles["desktop-mega-menu"],
+          )}
+        >
           <MegaMenu navItems={selectedItem.children} />
         </div>
       )}


### PR DESCRIPTION
I have updated the `NavBar`: 

- The `Megamenu` now 'floats' on top of content when in desktop mode (previously this was just in mobile). This was achieved by adding `position: absolute` for large screens. `w-100` was needed to make it span across the whole screen.
- A box shadow was re-used from another component and a value of grey was picked that looked good
- I have also moved the `display: none` from the `scss` and used bootstrap class instead