### PR TITLE
Onsppt 249 homepage stats section fixes

### DIFF
--- a/src/components/Home/StatisticsAndText/StatisticsAndText.module.scss
+++ b/src/components/Home/StatisticsAndText/StatisticsAndText.module.scss
@@ -6,6 +6,7 @@
 
 .statistics-and-text-bg {
   background-color: $color-brand-secondary-100;
+  padding: 5rem 0;
 }
 
 .statistics-and-text__content-container {

--- a/src/components/Home/StatisticsAndText/StatisticsAndText.tsx
+++ b/src/components/Home/StatisticsAndText/StatisticsAndText.tsx
@@ -9,7 +9,7 @@ import styles from "./StatisticsAndText.module.scss";
 export const StatisticsAndText: FC<StatisticsAndTextProps> = (props) => {
   return (
     <div className={clsx("w-100", styles["statistics-and-text-bg"])}>
-      <div className={clsx("container-lg", "py-4")}>
+      <div className={clsx("container-lg")}>
         <div
           className={clsx(
             "row",

--- a/src/content/Home/statisticsAndText.json
+++ b/src/content/Home/statisticsAndText.json
@@ -38,7 +38,7 @@
       "image": {
         "id": "stat-card-image-2",
         "altText": "Bar chart showing deaths from COVID-19 as of August 2025.",
-        "srcPath": "./images/plots/line-chart.svg"
+        "srcPath": "./images/plots/histogram.svg"
       }
     },
     {
@@ -52,7 +52,7 @@
       "image": {
         "id": "stat-card-image-3",
         "altText": "Line chart showing people pushed into extreme poverty due to COVID-19.",
-        "srcPath": "./images/plots/histogram.svg"
+        "srcPath": "./images/plots/line-chart.svg"
       }
     },
     {


### PR DESCRIPTION
### What 
Ticket: https://anddigitaltransformation.atlassian.net/browse/ONSPPT-249

#### Code changes 
- Corrected image used in `CardStat`s to be correct compared to figma
- Add top and bottom padding to the statistics section used in homepage