### PR TITLE
Quick fix: Card Unit currently without content shouldn't redirect to homepage

### DIFF
--- a/src/content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json
+++ b/src/content/learning-resources/data-analysis/epidemiological-analysis/unitBlock.json
@@ -25,7 +25,7 @@
     {
       "id": "313d84a0-6cb4-42f4-a5dc-ba66312a0003",
       "link": {
-        "href": "/",
+        "href": "#",
         "label": "Mortality Analysis"
       },
       "subTitle": "Leveraging existing administrative datasets to monitor trends.",


### PR DESCRIPTION
### What 
The `CardUnit` titled `Mortality Analysis` doesn't have its own content or `LearningModule` and currently points to the homepage. I've changed the `href` to be `#` instead of `/` so that it won't redirect user, which I thought was confusing.
 
<img width="903" height="542" alt="image" src="https://github.com/user-attachments/assets/5767802d-4898-4966-aa88-0fde368c8099" />
