### PR TITLE
Try now buttons in carousel shouldn't point to places not set up

### DIFF
--- a/src/content/Home/carousel.json
+++ b/src/content/Home/carousel.json
@@ -7,7 +7,7 @@
       "title": "Sample size calculator",
       "subTitle": "Estimates required sample size for a study or survey.",
       "link": {
-        "href": "/tools/sample-size-calculator",
+        "href": "/",
         "label": "Try now"
       }
     },
@@ -17,7 +17,7 @@
       "title": "Question bank",
       "subTitle": "Curated library of ready-to-use, evidence-backed questions.",
       "link": {
-        "href": "/tools/question-bank",
+        "href": "/tools/question-bank/",
         "label": "Try now"
       }
     },
@@ -27,7 +27,7 @@
       "title": "Modelling dashboard",
       "subTitle": "An infectious disease modelling dashboard.",
       "link": {
-        "href": "/tools/modelling-dashboard",
+        "href": "/",
         "label": "Try now"
       }
     },
@@ -37,7 +37,7 @@
       "title": "Survey analysis tool",
       "subTitle": "Analyze survey data with automated insights and visualizations.",
       "link": {
-        "href": "/tools/survey-analysis",
+        "href": "/",
         "label": "Try now"
       }
     },
@@ -47,7 +47,7 @@
       "title": "Risk assessment calculator",
       "subTitle": "Calculate risk scores for various health scenarios.",
       "link": {
-        "href": "/tools/risk-calculator",
+        "href": "/",
         "label": "Try now"
       }
     },
@@ -57,7 +57,7 @@
       "title": "Data visualization tool",
       "subTitle": "Create interactive charts and graphs from your data.",
       "link": {
-        "href": "/tools/data-visualization",
+        "href": "/",
         "label": "Try now"
       }
     }


### PR DESCRIPTION
### What 

In the carousel, the links for `Try Now ->` should only point to pages that exist