### PR TITLE
Fix LearningResources to stack properly on mobile

### DIFF
--- a/src/components/Core/LearningResource/LearningResource.tsx
+++ b/src/components/Core/LearningResource/LearningResource.tsx
@@ -14,7 +14,7 @@ export const LearningResource: FC<LearningResourceProps> = (props) => {
     <div className={clsx("w-100", styles["learning-resource__container"])}>
       <div className={clsx("container-lg", "py-4")}>
         <div className={clsx("row")}>
-          <div className={clsx("col-md-3", "")}>
+          <div className={clsx("col-md-3")}>
             <LearningModuleNav {...props.learningModuleNav} />
           </div>
           <div className={clsx("col-md-9", "d-flex", "flex-column", "gap-4")}>


### PR DESCRIPTION
### What 
Ticket: https://anddigitaltransformation.atlassian.net/browse/ONSPPT-253

#### Code changes
The `start` section of `/learning-resources/data-analysis/epidemiological-analysis/introduction-to-mortality-analysis/` uses `LearningModule` 

The other chapters use `LearningResources`, which previously was not set up to use bootstrap's `row`/`col` correctly. This has been fixed, and will now be stacked on mobile. This change matches the classes in `LearningModule` so that there is consistency between `start` and the other chapters 