### PR TITLE
Onsppt 221 align components to underlying 12 col grid

### DIFF
--- a/src/components/Home/StatisticsAndText/StatisticsAndText.module.scss
+++ b/src/components/Home/StatisticsAndText/StatisticsAndText.module.scss
@@ -6,7 +6,9 @@
 
 .statistics-and-text-bg {
   background-color: $color-brand-secondary-100;
-  padding: 5rem 0;
+  @include media-breakpoint-up(lg) {
+    padding: 5rem 0;
+  }
 }
 
 .statistics-and-text__ref-link {

--- a/src/components/Home/StatisticsAndText/StatisticsAndText.tsx
+++ b/src/components/Home/StatisticsAndText/StatisticsAndText.tsx
@@ -9,9 +9,9 @@ import styles from "./StatisticsAndText.module.scss";
 export const StatisticsAndText: FC<StatisticsAndTextProps> = (props) => {
   return (
     <div className={clsx("w-100", styles["statistics-and-text-bg"])}>
-      <div className={clsx("container-lg")}>
+      <div className={clsx("container-lg", "py-4")}>
         <div className={clsx("row")}>
-          <div className={clsx("col-lg-5")}>
+          <div className={clsx("col-lg-5", "pb-5")}>
             <h1
               className={clsx(
                 "fw-bold",


### PR DESCRIPTION
### What
Ticket: https://anddigitaltransformation.atlassian.net/browse/ONSPPT-221

#### Code change
Updated `src/components/Home/StatisticsAndText/StatisticsAndText.tsx` to align with `12-col-grid` system:

- Updated the cols such that the content is split between`"col-lg-5"` and `"col-lg-7"` columns
- Within the second column the `CardStat`s are organised using `col-auto` ... I know, I know.. but actually I think this works well in this case. We want to make sure the cards fill the columns that are available to them and do not get warped. Using `col-auto` works well to achieve this

Updated `src/components/Home/StatisticsAndText/StatisticsAndText.module.scss`

- removed `max-width`
- Made sure the additional padding we put on this section to make the pages look better is only applied on large screens 

#### Note 
As part of this ticket other components are flagged as needing aligning to `12-col-grid` system. I believe the others have already been done bar the `Carousel` 
