### PR TITLE
ONSPPT-424: bug fix for search results (and unit chapter navigation)

### DIFF
--- a/src/components/Molecules/SearchResults/SearchResults.tsx
+++ b/src/components/Molecules/SearchResults/SearchResults.tsx
@@ -24,6 +24,7 @@ const SearchResultItem: FC<SearchResultItemProps> = (props) => {
         href={props.link.href}
         target={props.link.target}
         aria-disabled={props.link.disabled}
+        className="search-result-item-link" // This class is needed for look-up logic within the handleClickOutside functionality of NavBar.tsx
       >
         {props.link.label}
       </a>

--- a/src/components/Organisms/Core/NavBar/NavBar.tsx
+++ b/src/components/Organisms/Core/NavBar/NavBar.tsx
@@ -161,14 +161,16 @@ function handleClickOutside(
 ) {
   useEffect(() => {
     const triggerClickOutside = (event: MouseEvent | TouchEvent) => {
-      // console.log(event.target.classList)
       if (ref.current && !ref.current.contains(event.target as Node)) {
         callback();
       }
 
+      if (!(event.target instanceof HTMLElement)) return;
+
       // Unfocus Search if the search result directs to the section of the page the user is already located
       if (event.target.classList.contains("search-result-item-link")) {
-        if (window.location.href.includes(event.target.getAttribute("href"))) {
+        const href = event.target.getAttribute("href");
+        if (href != null && window.location.href.includes(href)) {
           callback();
         }
       }

--- a/src/components/Organisms/Core/NavBar/NavBar.tsx
+++ b/src/components/Organisms/Core/NavBar/NavBar.tsx
@@ -25,6 +25,19 @@ export const NavBar: FC<NavBarProps> = (props) => {
     setIsSearchOpen(false);
   });
 
+  // Unfocus Search if the search result directs to a different section of a page the user is already on
+  useEffect(() => {
+    const handleHashChange = () => {
+      setIsSearchOpen(false);
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+
+    return () => {
+      window.removeEventListener("hashchange", handleHashChange);
+    };
+  }, []);
+
   function toggleDesktopNav(expandableItem: ExpandableItemData) {
     if (expandableItem._uid === openId) {
       closeMegamenu();
@@ -148,8 +161,16 @@ function handleClickOutside(
 ) {
   useEffect(() => {
     const triggerClickOutside = (event: MouseEvent | TouchEvent) => {
+      // console.log(event.target.classList)
       if (ref.current && !ref.current.contains(event.target as Node)) {
         callback();
+      }
+
+      // Unfocus Search if the search result directs to the section of the page the user is already located
+      if (event.target.classList.contains("search-result-item-link")) {
+        if (window.location.href.includes(event.target.getAttribute("href"))) {
+          callback();
+        }
       }
     };
     document.addEventListener("mousedown", triggerClickOutside);

--- a/src/components/Organisms/Unit/Unit/Unit.tsx
+++ b/src/components/Organisms/Unit/Unit/Unit.tsx
@@ -67,12 +67,11 @@ export const Unit: FC<UnitProps> = ({ story }) => {
       // Decode where browser encoding may cause mismatch
       const hash = decodeURIComponent(rawHash);
 
-      // Find match
       const targetChapter = chapters.find(
         (ch: Chapter) => slugify(ch.title, { lower: true }) === hash,
       );
 
-      if (targetChapter && targetChapter._uid !== selectedChapterId) {
+      if (targetChapter) {
         setSelectedChapterId(targetChapter._uid);
         window.scrollTo({ top: 0, behavior: "smooth" });
       }


### PR DESCRIPTION
### What

- Fixed a bug in search results that was preventing results within the current page closing the SearchBar successfully
- Fixed a bug within the unit chapters list which was preventing correct navigation to the overview sections

Ticket: https://anddigitaltransformation.atlassian.net/browse/ONSPPT-424

#### Code changes:

- Updated `https://anddigitaltransformation.atlassian.net/browse/ONSPPT-424` to provide an identifier on `SearchResultItem` links that is used in the lookup functionality of `handeClickOutside` within the `NavBar` component
- Updated `src/components/Organisms/Core/NavBar/NavBar.tsx` for:
   - Logic that will close the `NavBar` search elements if the result directs to a new section of the page the user is already on (hash changes)
   - Logic that will close the `NavBar` search elements if the result directs to the current section of that the user is already on (no hash changes)
- Updated `src/components/Organisms/Unit/Unit/Unit.tsx` to address a bug that was preventing successful navigation back to the overview section of the Learning Resources pages
